### PR TITLE
Add AnimaDex-backed caption order correction setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ _archive/
 gui/gui_settings.json
 configs/gui-methods/custom/
 near_twins_temp.toml
+/data/animadex/

--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,3 @@ _archive/
 gui/gui_settings.json
 configs/gui-methods/custom/
 near_twins_temp.toml
-/data/animadex/

--- a/docs/anima_prompt.md
+++ b/docs/anima_prompt.md
@@ -1,0 +1,244 @@
+# ANIMA Prompt Correction Core
+
+`library/anima_prompt/` is a dependency-light prompt and caption correction
+core for ANIMA-style tag ordering.
+
+The package is written as plain Python so it can be reused by CLI tools, GUI
+tools, and future ComfyUI nodes without importing ComfyUI, torch, model loading
+code, or taggers.
+
+## Goals
+
+- Parse Danbooru-style comma-separated prompts.
+- Preserve newline-separated caption files when using the `caption` profile.
+- Normalize tag spelling for lookup and duplicate detection.
+- Load local tag knowledge from CSV or JSONL indexes.
+- Use AnimaDex character and artist exports as the main character database.
+- Classify tags into ANIMA ordering sections.
+- Reorder captions so person count/type tags come before character tags.
+- Produce a correction result with warnings, unknown tags, duplicates, and token
+  metadata.
+
+## Non-Goals
+
+- No model loading.
+- No tagger integration.
+- No natural-language-to-tag conversion.
+- No fuzzy matching in the MVP.
+- No full AnimaDex Flask/SQLite dependency.
+- No committed downloaded database files or tokens.
+
+## Ordering Profile
+
+The default ANIMA ordering is:
+
+```text
+quality / meta / year / safety
+-> character count / person type
+-> character
+-> series / copyright
+-> artist
+-> general tags
+-> unknown tags
+```
+
+Example:
+
+```text
+masterpiece, best quality, newest, safe,
+1girl,
+hatsune miku,
+vocaloid,
+@artist_name,
+aqua eyes, twintails, detached sleeves
+```
+
+Important rules:
+
+- `1girl`, `1boy`, `1other`, `no humans`, and similar person tags are ordered
+  before character tags.
+- Character tags are ordered before series/copyright tags.
+- Series/copyright tags are ordered before artist tags.
+- Artist tags are rendered with ANIMA's `@artist_name` style.
+- General visual tags stay after the identity tags.
+
+## Data Sources
+
+The knowledge base can combine two sources:
+
+1. General Danbooru-style tag CSV or JSONL index.
+2. AnimaDex `characters.csv` and `artists.csv`, or their generated JSONL
+   indexes.
+
+Resolution priority:
+
+1. CLI argument.
+2. Environment variable.
+3. Workspace-local default path.
+
+Environment variables:
+
+- `ANIMA_PROMPT_TAG_CSV`
+- `ANIMA_PROMPT_TAG_INDEX`
+- `ANIMADEX_CHARACTERS_CSV`
+- `ANIMADEX_ARTISTS_CSV`
+- `ANIMADEX_CHARACTER_INDEX`
+- `ANIMADEX_ARTIST_INDEX`
+- `ANIMADEX_IMPORT_TOKEN`
+- `ANIMADEX_IMPORT_TOKEN_FILE`
+
+## AnimaDex Import
+
+AnimaDex data is expected to come from the official offline export flow:
+
+1. Open `animadex.net`.
+2. Create an offline dataset export token from the account page.
+3. Save the token outside the repository.
+4. Download `characters.csv` and `artists.csv` into the local ignored data
+   directory.
+5. Build JSONL indexes for faster repeated tests.
+
+Default paths:
+
+- Token on Windows:
+  `%APPDATA%\anima_prompt\animadex_import_token.json`
+- Token on other OSes:
+  `~/.config/anima_prompt/animadex_import_token.json`
+- CSV:
+  `data/animadex/import/characters.csv`
+  `data/animadex/import/artists.csv`
+- Index:
+  `data/animadex/index/character_index.jsonl`
+  `data/animadex/index/artist_index.jsonl`
+
+`data/animadex/` is ignored by git. Do not commit export tokens or downloaded
+CSV files.
+
+The import command follows the public AnimaDex export contract:
+
+- Manifest endpoint: `/api/export/manifest`
+- Token header: `X-Export-Token`
+- Token environment variable: `ANIMADEX_IMPORT_TOKEN`
+
+## CLI
+
+Build a general tag index:
+
+```powershell
+uv run python scripts/anima_prompt.py build-index `
+  --tag-csv tags.csv `
+  --output tag_index.jsonl
+```
+
+Save an AnimaDex export token:
+
+```powershell
+uv run python scripts/anima_prompt.py animadex-save-token
+```
+
+Download AnimaDex CSVs and build indexes:
+
+```powershell
+uv run python scripts/anima_prompt.py animadex-import --build-index
+```
+
+Build AnimaDex indexes from existing local CSVs:
+
+```powershell
+uv run python scripts/anima_prompt.py build-animadex-index `
+  --characters-csv data/animadex/import/characters.csv `
+  --artists-csv data/animadex/import/artists.csv `
+  --output-dir data/animadex/index
+```
+
+Inspect a prompt:
+
+```powershell
+uv run python scripts/anima_prompt.py check `
+  --text "long hair, 1girl"
+```
+
+Fix a prompt:
+
+```powershell
+uv run python scripts/anima_prompt.py fix `
+  --text "long_hair, @artist_name, hatsune_miku, vocaloid, 1girl"
+```
+
+Fix a newline-separated caption file in place:
+
+```powershell
+uv run python scripts/anima_prompt.py fix `
+  --profile caption `
+  --file image.txt `
+  --in-place
+```
+
+## Python API
+
+```python
+from library.anima_prompt import correct_prompt, load_knowledge_base
+
+kb = load_knowledge_base(
+    tag_index="tag_index.jsonl",
+    animadex_character_index="data/animadex/index/character_index.jsonl",
+    animadex_artist_index="data/animadex/index/artist_index.jsonl",
+)
+
+result = correct_prompt(
+    "long hair, @artist_name, vocaloid, hatsune miku, 1girl",
+    profile="prompt",
+    knowledge_base=kb,
+)
+
+print(result.text)
+print(result.warnings)
+print(result.unknown_tags)
+```
+
+## Module Layout
+
+- `parser.py`: prompt/caption tokenization and rendering.
+- `normalize.py`: tag normalization, lookup keys, artist rendering.
+- `models.py`: immutable result and token data models.
+- `knowledge.py`: local DB discovery and merged knowledge base lookup.
+- `animadex.py`: lightweight AnimaDex CSV import, token storage, and JSONL
+  index helpers.
+- `ordering.py`: ANIMA section classification and stable ordering.
+- `correction.py`: inspect/fix orchestration.
+- `cli.py`: command-line entry points.
+
+## Validation
+
+Run the focused test suite:
+
+```powershell
+uv run python -m pytest tests\test_anima_prompt.py -q
+```
+
+Run lint:
+
+```powershell
+uv run python -m ruff check library\anima_prompt scripts\anima_prompt.py tests\test_anima_prompt.py
+```
+
+Run syntax checks:
+
+```powershell
+uv run python -m py_compile `
+  library\anima_prompt\__init__.py `
+  library\anima_prompt\animadex.py `
+  library\anima_prompt\knowledge.py `
+  library\anima_prompt\cli.py `
+  tests\test_anima_prompt.py
+```
+
+## Future Work
+
+- Alias override support.
+- Order profile configuration.
+- Conflict reports for character/series mismatch.
+- Optional fuzzy matching.
+- Batch caption directory fix command.
+- GUI integration.
+- ComfyUI prompt-corrector node using the same core.

--- a/docs/anima_prompt.md
+++ b/docs/anima_prompt.md
@@ -94,8 +94,8 @@ AnimaDex data is expected to come from the official offline export flow:
 1. Open `animadex.net`.
 2. Create an offline dataset export token from the account page.
 3. Save the token outside the repository.
-4. Download `characters.csv` and `artists.csv` into the local ignored data
-   directory.
+4. Download `characters.csv` and `artists.csv` into the local ignored
+   `models/` directory.
 5. Build JSONL indexes for faster repeated tests.
 
 Default paths:
@@ -105,13 +105,13 @@ Default paths:
 - Token on other OSes:
   `~/.config/anima_prompt/animadex_import_token.json`
 - CSV:
-  `data/animadex/import/characters.csv`
-  `data/animadex/import/artists.csv`
+  `models/animadex/import/characters.csv`
+  `models/animadex/import/artists.csv`
 - Index:
-  `data/animadex/index/character_index.jsonl`
-  `data/animadex/index/artist_index.jsonl`
+  `models/animadex/index/character_index.jsonl`
+  `models/animadex/index/artist_index.jsonl`
 
-`data/animadex/` is ignored by git. Do not commit export tokens or downloaded
+`models/animadex/` is ignored by git. Do not commit export tokens or downloaded
 CSV files.
 
 The import command follows the public AnimaDex export contract:
@@ -146,9 +146,9 @@ Build AnimaDex indexes from existing local CSVs:
 
 ```powershell
 uv run python scripts/anima_prompt.py build-animadex-index `
-  --characters-csv data/animadex/import/characters.csv `
-  --artists-csv data/animadex/import/artists.csv `
-  --output-dir data/animadex/index
+  --characters-csv models/animadex/import/characters.csv `
+  --artists-csv models/animadex/import/artists.csv `
+  --output-dir models/animadex/index
 ```
 
 Inspect a prompt:
@@ -181,8 +181,8 @@ from library.anima_prompt import correct_prompt, load_knowledge_base
 
 kb = load_knowledge_base(
     tag_index="tag_index.jsonl",
-    animadex_character_index="data/animadex/index/character_index.jsonl",
-    animadex_artist_index="data/animadex/index/artist_index.jsonl",
+    animadex_character_index="models/animadex/index/character_index.jsonl",
+    animadex_artist_index="models/animadex/index/artist_index.jsonl",
 )
 
 result = correct_prompt(

--- a/gui/app.py
+++ b/gui/app.py
@@ -23,6 +23,7 @@ from PySide6.QtWidgets import (
     QMessageBox,
     QPlainTextEdit,
     QPushButton,
+    QScrollArea,
     QSpinBox,
     QStackedWidget,
     QTabWidget,
@@ -183,7 +184,8 @@ class SettingsDialog(QDialog):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setWindowTitle(t("settings_title"))
-        self.setMinimumWidth(560)
+        self.setMinimumWidth(640)
+        self.resize(720, 640)
         # Set when the user opts into an immediate reload; MainWindow checks it after exec().
         self.reload_requested = False
 
@@ -229,6 +231,7 @@ class SettingsDialog(QDialog):
         conf_row.addWidget(self.conf_spin)
         conf_row.addStretch()
         caption_lay.addLayout(conf_row)
+        self._add_tip_label(caption_lay, t("settings_autotag_confidence_tooltip"))
 
         self.caption_validate_artist_check = QCheckBox(
             t("settings_caption_validate_artist_tags")
@@ -243,6 +246,9 @@ class SettingsDialog(QDialog):
             lambda checked: set_setting("caption_validate_artist_tags", bool(checked))
         )
         caption_lay.addWidget(self.caption_validate_artist_check)
+        self._add_tip_label(
+            caption_lay, t("settings_caption_validate_artist_tags_tooltip")
+        )
 
         self.caption_insert_no_artist_check = QCheckBox(
             t("settings_caption_insert_no_artist")
@@ -257,10 +263,12 @@ class SettingsDialog(QDialog):
             lambda checked: set_setting("caption_insert_no_artist", bool(checked))
         )
         caption_lay.addWidget(self.caption_insert_no_artist_check)
+        self._add_tip_label(caption_lay, t("settings_caption_insert_no_artist_tooltip"))
 
         overrides_label = QLabel(t("settings_caption_artist_overrides"))
         overrides_label.setToolTip(t("settings_caption_artist_overrides_tooltip"))
         caption_lay.addWidget(overrides_label)
+        self._add_tip_label(caption_lay, t("settings_caption_artist_overrides_tooltip"))
         self.caption_artist_overrides_edit = QPlainTextEdit(
             str(get_setting("caption_artist_overrides", ""))
         )
@@ -282,6 +290,9 @@ class SettingsDialog(QDialog):
         exclusions_label = QLabel(t("settings_caption_artist_exclusions"))
         exclusions_label.setToolTip(t("settings_caption_artist_exclusions_tooltip"))
         caption_lay.addWidget(exclusions_label)
+        self._add_tip_label(
+            caption_lay, t("settings_caption_artist_exclusions_tooltip")
+        )
         self.caption_artist_exclusions_edit = QPlainTextEdit(
             str(get_setting("caption_artist_exclusions", ""))
         )
@@ -352,9 +363,6 @@ class SettingsDialog(QDialog):
         dbg_row.addWidget(self.debug_report_btn)
         prefs_lay.addLayout(dbg_row)
 
-        lay.addWidget(caption_group)
-        lay.addWidget(prefs_group)
-
         mcp_group = QGroupBox(t("settings_mcp_header"))
         mcp_lay = QVBoxLayout(mcp_group)
         self._add_command_block(
@@ -363,7 +371,12 @@ class SettingsDialog(QDialog):
         self._add_command_block(
             mcp_lay, t("settings_mcp_desc_json"), _mcp_json_config(), height=140
         )
-        lay.addWidget(mcp_group)
+
+        tabs = QTabWidget()
+        tabs.addTab(self._scroll_tab(caption_group), t("settings_caption_header"))
+        tabs.addTab(self._scroll_tab(prefs_group), t("settings_prefs_header"))
+        tabs.addTab(self._scroll_tab(mcp_group), t("settings_mcp_header"))
+        lay.addWidget(tabs, 1)
 
         btn_bar = QHBoxLayout()
         btn_bar.addStretch()
@@ -371,6 +384,19 @@ class SettingsDialog(QDialog):
         close.clicked.connect(self.close)
         btn_bar.addWidget(close)
         lay.addLayout(btn_bar)
+
+    def _scroll_tab(self, widget: QWidget) -> QScrollArea:
+        area = QScrollArea()
+        area.setWidgetResizable(True)
+        area.setWidget(widget)
+        return area
+
+    def _add_tip_label(self, layout: QVBoxLayout, text: str) -> None:
+        label = QLabel(text)
+        label.setWordWrap(True)
+        label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        label.setContentsMargins(18, 0, 0, 8)
+        layout.addWidget(label)
 
     def _add_command_block(
         self, layout: QVBoxLayout, desc: str, text: str, height: int

--- a/gui/app.py
+++ b/gui/app.py
@@ -205,6 +205,8 @@ class SettingsDialog(QDialog):
 
         prefs_group = QGroupBox(t("settings_prefs_header"))
         prefs_lay = QVBoxLayout(prefs_group)
+        caption_group = QGroupBox(t("settings_caption_header"))
+        caption_lay = QVBoxLayout(caption_group)
 
         # Autotagger confidence floor (applied on top of the model's per-tag F1
         # thresholds; see AnimaTagger.predict_caption min_confidence).
@@ -226,7 +228,77 @@ class SettingsDialog(QDialog):
         self.conf_spin.setFixedWidth(125)
         conf_row.addWidget(self.conf_spin)
         conf_row.addStretch()
-        prefs_lay.addLayout(conf_row)
+        caption_lay.addLayout(conf_row)
+
+        self.caption_validate_artist_check = QCheckBox(
+            t("settings_caption_validate_artist_tags")
+        )
+        self.caption_validate_artist_check.setToolTip(
+            t("settings_caption_validate_artist_tags_tooltip")
+        )
+        self.caption_validate_artist_check.setChecked(
+            bool(get_setting("caption_validate_artist_tags", False))
+        )
+        self.caption_validate_artist_check.toggled.connect(
+            lambda checked: set_setting("caption_validate_artist_tags", bool(checked))
+        )
+        caption_lay.addWidget(self.caption_validate_artist_check)
+
+        self.caption_insert_no_artist_check = QCheckBox(
+            t("settings_caption_insert_no_artist")
+        )
+        self.caption_insert_no_artist_check.setToolTip(
+            t("settings_caption_insert_no_artist_tooltip")
+        )
+        self.caption_insert_no_artist_check.setChecked(
+            bool(get_setting("caption_insert_no_artist", False))
+        )
+        self.caption_insert_no_artist_check.toggled.connect(
+            lambda checked: set_setting("caption_insert_no_artist", bool(checked))
+        )
+        caption_lay.addWidget(self.caption_insert_no_artist_check)
+
+        overrides_label = QLabel(t("settings_caption_artist_overrides"))
+        overrides_label.setToolTip(t("settings_caption_artist_overrides_tooltip"))
+        caption_lay.addWidget(overrides_label)
+        self.caption_artist_overrides_edit = QPlainTextEdit(
+            str(get_setting("caption_artist_overrides", ""))
+        )
+        self.caption_artist_overrides_edit.setPlaceholderText(
+            t("settings_caption_artist_overrides_placeholder")
+        )
+        self.caption_artist_overrides_edit.setToolTip(
+            t("settings_caption_artist_overrides_tooltip")
+        )
+        self.caption_artist_overrides_edit.setFixedHeight(58)
+        self.caption_artist_overrides_edit.textChanged.connect(
+            lambda: set_setting(
+                "caption_artist_overrides",
+                self.caption_artist_overrides_edit.toPlainText(),
+            )
+        )
+        caption_lay.addWidget(self.caption_artist_overrides_edit)
+
+        exclusions_label = QLabel(t("settings_caption_artist_exclusions"))
+        exclusions_label.setToolTip(t("settings_caption_artist_exclusions_tooltip"))
+        caption_lay.addWidget(exclusions_label)
+        self.caption_artist_exclusions_edit = QPlainTextEdit(
+            str(get_setting("caption_artist_exclusions", ""))
+        )
+        self.caption_artist_exclusions_edit.setPlaceholderText(
+            t("settings_caption_artist_exclusions_placeholder")
+        )
+        self.caption_artist_exclusions_edit.setToolTip(
+            t("settings_caption_artist_exclusions_tooltip")
+        )
+        self.caption_artist_exclusions_edit.setFixedHeight(58)
+        self.caption_artist_exclusions_edit.textChanged.connect(
+            lambda: set_setting(
+                "caption_artist_exclusions",
+                self.caption_artist_exclusions_edit.toPlainText(),
+            )
+        )
+        caption_lay.addWidget(self.caption_artist_exclusions_edit)
 
         # Closing the dialog rebuilds the window so each tab's per-widget tokens (gui.theme.tok) repaint.
         theme_row = QHBoxLayout()
@@ -280,6 +352,7 @@ class SettingsDialog(QDialog):
         dbg_row.addWidget(self.debug_report_btn)
         prefs_lay.addLayout(dbg_row)
 
+        lay.addWidget(caption_group)
         lay.addWidget(prefs_group)
 
         mcp_group = QGroupBox(t("settings_mcp_header"))

--- a/gui/i18n/cn.py
+++ b/gui/i18n/cn.py
@@ -414,11 +414,31 @@ STRINGS: dict[str, str] = {
     "settings_btn_tooltip": "应用设置 —— 语言、偏好设置、MCP 服务器注册",
     "settings_title": "设置",
     "settings_prefs_header": "偏好设置",
+    "settings_caption_header": "标注 / 自动打标",
     "settings_autotag_confidence": "自动打标置信度:",
     "settings_autotag_confidence_tooltip": (
         "在打标器各标签阈值之上额外应用的概率下限（0–1）。"
         "数值越高，保留的标签越少但越可靠。默认 0.50。"
     ),
+    "settings_caption_validate_artist_tags": "验证艺术家标签",
+    "settings_caption_validate_artist_tags_tooltip": (
+        "修正标注顺序时，只把 AnimaDex artists 和下方手动列表中的标签作为 @artist。"
+        "未注册的 @trigger 不会移动到艺术家位置。"
+    ),
+    "settings_caption_insert_no_artist": "插入 no-artist",
+    "settings_caption_insert_no_artist_tooltip": (
+        "没有艺术家标签，或所有 @ 标签都被验证排除时，在艺术家位置插入 @no-artist。"
+    ),
+    "settings_caption_artist_overrides": "追加艺术家标签:",
+    "settings_caption_artist_overrides_tooltip": (
+        "输入要当作艺术家处理的手动触发词，可用逗号或换行分隔。"
+    ),
+    "settings_caption_artist_overrides_placeholder": "special_trigger\nmanual artist",
+    "settings_caption_artist_exclusions": "艺术家标签例外:",
+    "settings_caption_artist_exclusions_tooltip": (
+        "输入即使以 @ 开头也不作为艺术家处理的触发词，可用逗号或换行分隔。"
+    ),
+    "settings_caption_artist_exclusions_placeholder": "no_artist_trigger\nstyle token",
     "settings_theme": "主题:",
     "settings_theme_tooltip": (
         "界面整体配色主题，立即生效；关闭设置窗口时会重建窗口以完全重绘。"

--- a/gui/i18n/cn.py
+++ b/gui/i18n/cn.py
@@ -508,6 +508,7 @@ STRINGS: dict[str, str] = {
     "model_sam3": "SAM3 — 对话气泡蒙版",
     "model_mit": "MIT — 漫画文字蒙版",
     "model_pe": "PE-Core-L14-336 — 视觉编码器 (CMMD 验证 / DCW)",
+    "model_animadex": "AnimaDex — 标注角色 / 艺术家数据库",
     # HuggingFace 认证（模型对话框）
     "models_hf_token_placeholder": "粘贴你的 HuggingFace 令牌 (hf_…)",
     "models_hf_authenticate": "认证",
@@ -521,6 +522,27 @@ STRINGS: dict[str, str] = {
     "models_hf_authenticating": "正在认证…",
     "models_hf_logged_in": "✓ 已登录为 {name}。",
     "models_hf_login_failed": "认证失败：{err}",
+    # AnimaDex import (Models dialog)
+    "models_animadex_header": "AnimaDex 标注数据库",
+    "models_animadex_token_placeholder": "粘贴你的 AnimaDex export token",
+    "models_animadex_save_token": "保存令牌",
+    "models_animadex_import": "下载 CSV",
+    "models_animadex_hint": (
+        "用于标注顺序修正中的角色、作品和艺术家判定。"
+        '打开 <a href="https://animadex.net">animadex.net</a> 创建 offline '
+        "export token 后，将 characters.csv 和 artists.csv 下载到 "
+        "models/animadex/。"
+    ),
+    "models_animadex_present": "✓ AnimaDex CSV 和索引已可用。",
+    "models_animadex_missing": "尚未下载 AnimaDex CSV。",
+    "models_animadex_token_empty": "请先粘贴令牌，或准备已保存的令牌。",
+    "models_animadex_saving": "正在保存 AnimaDex 令牌…",
+    "models_animadex_token_saved": "✓ AnimaDex 令牌已保存。",
+    "models_animadex_importing": "正在下载 AnimaDex CSV 并构建索引…",
+    "models_animadex_import_done": (
+        "✓ AnimaDex 导入完成：{characters} 个角色，{artists} 个艺术家。"
+    ),
+    "models_animadex_failed": "AnimaDex 导入失败：{err}",
     # Update dialog
     "update_title": "更新 anima_lora",
     "update_warning": "更新会从 GitHub 拉取最新版本并覆盖工作树 "

--- a/gui/i18n/cn.py
+++ b/gui/i18n/cn.py
@@ -371,6 +371,7 @@ STRINGS: dict[str, str] = {
     "caption_autotag_error": "自动标注失败：{err}",
     "caption_autotag_empty": "标注器未为该图像返回任何标签。",
     "caption_order_correct": "修正顺序",
+    "caption_order_correct_all": "修正当前目录全部标注",
     "caption_order_correct_tooltip": (
         "按 ANIMA 标注规则整理人数、角色、作品、作者和普通标签顺序。"
         "修正前的文本会保存到标注历史。"
@@ -378,6 +379,9 @@ STRINGS: dict[str, str] = {
     "caption_order_correct_empty": "没有可修正的标注。",
     "caption_order_correct_no_change": "无需修正标注顺序。",
     "caption_order_correct_failed": "标注顺序修正失败：{err}",
+    "caption_order_correct_all_done": (
+        "标注顺序修正完成：{changed} 个已更改，{skipped} 个无标注。"
+    ),
     "caption_versions": "历史……",
     "caption_history_reason_order_correct": "顺序修正前",
     "caption_dirty_marker": " *",

--- a/gui/i18n/cn.py
+++ b/gui/i18n/cn.py
@@ -370,7 +370,16 @@ STRINGS: dict[str, str] = {
     ),
     "caption_autotag_error": "自动标注失败：{err}",
     "caption_autotag_empty": "标注器未为该图像返回任何标签。",
+    "caption_order_correct": "修正顺序",
+    "caption_order_correct_tooltip": (
+        "按 ANIMA 标注规则整理人数、角色、作品、作者和普通标签顺序。"
+        "修正前的文本会保存到标注历史。"
+    ),
+    "caption_order_correct_empty": "没有可修正的标注。",
+    "caption_order_correct_no_change": "无需修正标注顺序。",
+    "caption_order_correct_failed": "标注顺序修正失败：{err}",
     "caption_versions": "历史……",
+    "caption_history_reason_order_correct": "顺序修正前",
     "caption_dirty_marker": " *",
     "caption_diff_stats": "(+{add} / −{rem})",
     "caption_diff_clean": "(无变化)",

--- a/gui/i18n/en.py
+++ b/gui/i18n/en.py
@@ -436,6 +436,7 @@ STRINGS: dict[str, str] = {
     "caption_autotag_error": "Autotag failed: {err}",
     "caption_autotag_empty": "The tagger returned no tags for this image.",
     "caption_order_correct": "Fix order",
+    "caption_order_correct_all": "Fix all captions in this directory",
     "caption_order_correct_tooltip": (
         "Reorder count, character, series, artist, and general tags for ANIMA "
         "caption rules. The pre-correction text is saved to caption history."
@@ -443,6 +444,9 @@ STRINGS: dict[str, str] = {
     "caption_order_correct_empty": "There is no caption to correct.",
     "caption_order_correct_no_change": "No caption order changes were needed.",
     "caption_order_correct_failed": "Caption order correction failed: {err}",
+    "caption_order_correct_all_done": (
+        "Caption order correction complete: {changed} changed, {skipped} missing captions."
+    ),
     "caption_versions": "Versions…",
     "caption_history_reason_order_correct": "before order fix",
     "caption_dirty_marker": " *",

--- a/gui/i18n/en.py
+++ b/gui/i18n/en.py
@@ -585,6 +585,7 @@ STRINGS: dict[str, str] = {
     "model_sam3": "SAM3 — text-bubble masking",
     "model_mit": "MIT — manga text masking",
     "model_pe": "PE-Core-L14-336 — vision encoder (CMMD validation / DCW)",
+    "model_animadex": "AnimaDex — caption character / artist database",
     # HuggingFace authentication (Models dialog)
     "models_hf_token_placeholder": "Paste your HuggingFace token (hf_…)",
     "models_hf_authenticate": "Authenticate",
@@ -598,6 +599,27 @@ STRINGS: dict[str, str] = {
     "models_hf_authenticating": "Authenticating…",
     "models_hf_logged_in": "✓ Logged in as {name}.",
     "models_hf_login_failed": "Authentication failed: {err}",
+    # AnimaDex import (Models dialog)
+    "models_animadex_header": "AnimaDex caption database",
+    "models_animadex_token_placeholder": "Paste your AnimaDex export token",
+    "models_animadex_save_token": "Save token",
+    "models_animadex_import": "Download CSVs",
+    "models_animadex_hint": (
+        "Used by caption order correction for character, copyright, and artist "
+        'lookup. Open <a href="https://animadex.net">animadex.net</a>, create '
+        "an offline export token, then download characters.csv and artists.csv "
+        "into models/animadex/."
+    ),
+    "models_animadex_present": "✓ AnimaDex CSVs and indexes are available.",
+    "models_animadex_missing": "AnimaDex CSVs are not downloaded yet.",
+    "models_animadex_token_empty": "Paste a token first, or save one before downloading.",
+    "models_animadex_saving": "Saving AnimaDex token…",
+    "models_animadex_token_saved": "✓ AnimaDex token saved.",
+    "models_animadex_importing": "Downloading AnimaDex CSVs and building indexes…",
+    "models_animadex_import_done": (
+        "✓ AnimaDex import complete: {characters} characters, {artists} artists."
+    ),
+    "models_animadex_failed": "AnimaDex import failed: {err}",
     # Update dialog
     "update_title": "Update anima_lora",
     "update_warning": "Update will pull the latest release from GitHub and overwrite the working "

--- a/gui/i18n/en.py
+++ b/gui/i18n/en.py
@@ -480,11 +480,34 @@ STRINGS: dict[str, str] = {
     "settings_btn_tooltip": "Application settings — language, preferences, MCP server registration",
     "settings_title": "Settings",
     "settings_prefs_header": "Preferences",
+    "settings_caption_header": "Caption / Autotag",
     "settings_autotag_confidence": "Autotag confidence:",
     "settings_autotag_confidence_tooltip": (
         "Extra probability floor (0–1) applied on top of the tagger's per-tag "
         "thresholds. Higher = fewer, more confident tags. Default 0.50."
     ),
+    "settings_caption_validate_artist_tags": "Validate artist tags",
+    "settings_caption_validate_artist_tags_tooltip": (
+        "During caption order correction, only AnimaDex artists and the manual "
+        "artist list below are treated as @artist tags. Unregistered @triggers "
+        "do not move into the artist slot."
+    ),
+    "settings_caption_insert_no_artist": "Insert no-artist",
+    "settings_caption_insert_no_artist_tooltip": (
+        "Insert @no-artist as the artist placeholder when no artist tag exists "
+        "or all @tags are rejected by validation."
+    ),
+    "settings_caption_artist_overrides": "Additional artist tags:",
+    "settings_caption_artist_overrides_tooltip": (
+        "Comma- or newline-separated manual triggers to treat like artist tags."
+    ),
+    "settings_caption_artist_overrides_placeholder": "special_trigger\nmanual artist",
+    "settings_caption_artist_exclusions": "Artist tag exceptions:",
+    "settings_caption_artist_exclusions_tooltip": (
+        "Comma- or newline-separated triggers that must not be treated as artists, "
+        "even when they start with @."
+    ),
+    "settings_caption_artist_exclusions_placeholder": "no_artist_trigger\nstyle token",
     "settings_theme": "Theme:",
     "settings_theme_tooltip": (
         "Overall color theme for the interface. Applies immediately; the window "

--- a/gui/i18n/en.py
+++ b/gui/i18n/en.py
@@ -435,7 +435,16 @@ STRINGS: dict[str, str] = {
     ),
     "caption_autotag_error": "Autotag failed: {err}",
     "caption_autotag_empty": "The tagger returned no tags for this image.",
+    "caption_order_correct": "Fix order",
+    "caption_order_correct_tooltip": (
+        "Reorder count, character, series, artist, and general tags for ANIMA "
+        "caption rules. The pre-correction text is saved to caption history."
+    ),
+    "caption_order_correct_empty": "There is no caption to correct.",
+    "caption_order_correct_no_change": "No caption order changes were needed.",
+    "caption_order_correct_failed": "Caption order correction failed: {err}",
     "caption_versions": "Versions…",
+    "caption_history_reason_order_correct": "before order fix",
     "caption_dirty_marker": " *",
     "caption_diff_stats": "(+{add} / −{rem})",
     "caption_diff_clean": "(no changes)",

--- a/gui/i18n/ja.py
+++ b/gui/i18n/ja.py
@@ -385,6 +385,7 @@ STRINGS: dict[str, str] = {
     "caption_autotag_error": "自動タグ付けに失敗しました: {err}",
     "caption_autotag_empty": "タガーはこの画像のタグを返しませんでした。",
     "caption_order_correct": "順序補正",
+    "caption_order_correct_all": "このディレクトリの全キャプションを補正",
     "caption_order_correct_tooltip": (
         "ANIMA のキャプション規則に合わせて人数、キャラクター、作品、"
         "作者、一般タグの順序を整理します。補正前のテキストは履歴に保存されます。"
@@ -392,6 +393,9 @@ STRINGS: dict[str, str] = {
     "caption_order_correct_empty": "補正するキャプションがありません。",
     "caption_order_correct_no_change": "補正が必要な順序変更はありません。",
     "caption_order_correct_failed": "キャプション順序補正に失敗しました: {err}",
+    "caption_order_correct_all_done": (
+        "キャプション順序補正完了: {changed} 件変更、{skipped} 件キャプションなし。"
+    ),
     "caption_versions": "履歴…",
     "caption_history_reason_order_correct": "順序補正前",
     "caption_dirty_marker": " *",

--- a/gui/i18n/ja.py
+++ b/gui/i18n/ja.py
@@ -428,11 +428,32 @@ STRINGS: dict[str, str] = {
     "settings_btn_tooltip": "アプリ設定 — 言語、環境設定、MCP サーバー登録",
     "settings_title": "設定",
     "settings_prefs_header": "環境設定",
+    "settings_caption_header": "キャプション / 自動タグ",
     "settings_autotag_confidence": "自動タグの信頼度:",
     "settings_autotag_confidence_tooltip": (
         "タガーのタグ別しきい値に追加で適用する確率の下限（0–1）です。"
         "高いほど確信度の高いタグだけが少数残ります。既定値 0.50。"
     ),
+    "settings_caption_validate_artist_tags": "アーティストタグを検証",
+    "settings_caption_validate_artist_tags_tooltip": (
+        "キャプション順序補正時、AnimaDex artists と下の追加登録タグだけを "
+        "@artist タグとして扱います。未登録の @trigger はアーティスト位置へ移動しません。"
+    ),
+    "settings_caption_insert_no_artist": "no-artist を挿入",
+    "settings_caption_insert_no_artist_tooltip": (
+        "アーティストタグがない、または検証で除外された場合、"
+        "アーティスト位置のプレースホルダーとして @no-artist を挿入します。"
+    ),
+    "settings_caption_artist_overrides": "追加アーティストタグ:",
+    "settings_caption_artist_overrides_tooltip": (
+        "アーティストとして扱う手動トリガーをカンマまたは改行で入力します。"
+    ),
+    "settings_caption_artist_overrides_placeholder": "special_trigger\nmanual artist",
+    "settings_caption_artist_exclusions": "アーティストタグ例外:",
+    "settings_caption_artist_exclusions_tooltip": (
+        "@ で始まってもアーティストとして扱わないトリガーをカンマまたは改行で入力します。"
+    ),
+    "settings_caption_artist_exclusions_placeholder": "no_artist_trigger\nstyle token",
     "settings_theme": "テーマ:",
     "settings_theme_tooltip": (
         "インターフェース全体のカラーテーマです。即時に反映され、設定画面を閉じると"

--- a/gui/i18n/ja.py
+++ b/gui/i18n/ja.py
@@ -527,6 +527,7 @@ STRINGS: dict[str, str] = {
     "model_sam3": "SAM3 — テキストバブルマスキング",
     "model_mit": "MIT — 漫画テキストマスキング",
     "model_pe": "PE-Core-L14-336 — ビジョンエンコーダー (CMMD 検証 / DCW)",
+    "model_animadex": "AnimaDex — キャプション用キャラクター / アーティストDB",
     # HuggingFace 認証 (モデルダイアログ)
     "models_hf_token_placeholder": "HuggingFace トークンを貼り付けてください (hf_…)",
     "models_hf_authenticate": "認証",
@@ -540,6 +541,27 @@ STRINGS: dict[str, str] = {
     "models_hf_authenticating": "認証中…",
     "models_hf_logged_in": "✓ {name} としてログインしました。",
     "models_hf_login_failed": "認証に失敗しました: {err}",
+    # AnimaDex import (Models dialog)
+    "models_animadex_header": "AnimaDex キャプションデータベース",
+    "models_animadex_token_placeholder": "AnimaDex export token を貼り付けてください",
+    "models_animadex_save_token": "トークンを保存",
+    "models_animadex_import": "CSVをダウンロード",
+    "models_animadex_hint": (
+        "キャプション順序補正でキャラクター、作品、アーティスト判定に使用します。"
+        '<a href="https://animadex.net">animadex.net</a> で offline export '
+        "token を作成し、characters.csv と artists.csv を models/animadex/ "
+        "にダウンロードします。"
+    ),
+    "models_animadex_present": "✓ AnimaDex CSV とインデックスが利用可能です。",
+    "models_animadex_missing": "AnimaDex CSV はまだダウンロードされていません。",
+    "models_animadex_token_empty": "先にトークンを貼り付けるか、保存済みトークンを用意してください。",
+    "models_animadex_saving": "AnimaDex トークンを保存中…",
+    "models_animadex_token_saved": "✓ AnimaDex トークンを保存しました。",
+    "models_animadex_importing": "AnimaDex CSV をダウンロードし、インデックスを作成中…",
+    "models_animadex_import_done": (
+        "✓ AnimaDex import 完了: {characters} キャラクター、{artists} アーティスト。"
+    ),
+    "models_animadex_failed": "AnimaDex import に失敗しました: {err}",
     # Update dialog
     "update_title": "anima_lora の更新",
     "update_warning": "更新により GitHub から最新リリースが取得され、作業ツリーが上書きされます "

--- a/gui/i18n/ja.py
+++ b/gui/i18n/ja.py
@@ -384,7 +384,16 @@ STRINGS: dict[str, str] = {
     ),
     "caption_autotag_error": "自動タグ付けに失敗しました: {err}",
     "caption_autotag_empty": "タガーはこの画像のタグを返しませんでした。",
+    "caption_order_correct": "順序補正",
+    "caption_order_correct_tooltip": (
+        "ANIMA のキャプション規則に合わせて人数、キャラクター、作品、"
+        "作者、一般タグの順序を整理します。補正前のテキストは履歴に保存されます。"
+    ),
+    "caption_order_correct_empty": "補正するキャプションがありません。",
+    "caption_order_correct_no_change": "補正が必要な順序変更はありません。",
+    "caption_order_correct_failed": "キャプション順序補正に失敗しました: {err}",
     "caption_versions": "履歴…",
+    "caption_history_reason_order_correct": "順序補正前",
     "caption_dirty_marker": " *",
     "caption_diff_stats": "(+{add} / −{rem})",
     "caption_diff_clean": "(変更なし)",

--- a/gui/i18n/ko.py
+++ b/gui/i18n/ko.py
@@ -423,6 +423,7 @@ STRINGS: dict[str, str] = {
     "caption_autotag_error": "자동 태깅 실패: {err}",
     "caption_autotag_empty": "태거가 이 이미지에서 태그를 찾지 못했습니다.",
     "caption_order_correct": "순서 교정",
+    "caption_order_correct_all": "현재 디렉터리 전체 교정",
     "caption_order_correct_tooltip": (
         "ANIMA 캡션 규칙에 맞게 인원수, 캐릭터, 작품, 작가, 일반 태그 순서를 "
         "정리합니다. 적용 전 텍스트는 캡션 이력에 남습니다."
@@ -430,6 +431,9 @@ STRINGS: dict[str, str] = {
     "caption_order_correct_empty": "교정할 캡션이 없습니다.",
     "caption_order_correct_no_change": "교정할 순서 변경이 없습니다.",
     "caption_order_correct_failed": "캡션 순서 교정 실패: {err}",
+    "caption_order_correct_all_done": (
+        "캡션 순서 교정 완료: {changed}개 변경, {skipped}개 캡션 없음."
+    ),
     "caption_versions": "이력…",
     "caption_history_reason_order_correct": "순서 교정 전",
     "caption_dirty_marker": " *",

--- a/gui/i18n/ko.py
+++ b/gui/i18n/ko.py
@@ -467,11 +467,31 @@ STRINGS: dict[str, str] = {
     "settings_btn_tooltip": "앱 설정 — 언어, 환경설정, MCP 서버 등록",
     "settings_title": "설정",
     "settings_prefs_header": "환경설정",
+    "settings_caption_header": "캡션 / 자동 태깅",
     "settings_autotag_confidence": "자동 태그 신뢰도:",
     "settings_autotag_confidence_tooltip": (
         "태거의 태그별 임계값 위에 추가로 적용되는 확률 하한(0–1)입니다. "
         "높을수록 더 확실한 태그만 적게 남습니다. 기본값 0.50."
     ),
+    "settings_caption_validate_artist_tags": "작가태그 검증",
+    "settings_caption_validate_artist_tags_tooltip": (
+        "캡션 순서 교정 시 AnimaDex artists에 등록된 태그와 아래 추가 등록 태그만 "
+        "@작가 태그로 취급합니다. 등록되지 않은 @트리거는 작가 자리로 이동하지 않습니다."
+    ),
+    "settings_caption_insert_no_artist": "no artist 삽입",
+    "settings_caption_insert_no_artist_tooltip": (
+        "작가 태그가 없거나 검증에서 제외된 경우 작가 자리표시자로 @no-artist를 삽입합니다."
+    ),
+    "settings_caption_artist_overrides": "작가태그 추가:",
+    "settings_caption_artist_overrides_tooltip": (
+        "작가처럼 취급할 수동 트리거를 쉼표 또는 줄바꿈으로 입력합니다."
+    ),
+    "settings_caption_artist_overrides_placeholder": "special_trigger\nmanual artist",
+    "settings_caption_artist_exclusions": "작가태그 예외:",
+    "settings_caption_artist_exclusions_tooltip": (
+        "@로 시작해도 작가로 취급하지 않을 트리거를 쉼표 또는 줄바꿈으로 입력합니다."
+    ),
+    "settings_caption_artist_exclusions_placeholder": "no_artist_trigger\nstyle token",
     "settings_theme": "테마:",
     "settings_theme_tooltip": (
         "인터페이스 전체 색상 테마입니다. 즉시 적용되며, 설정 창을 닫으면 "

--- a/gui/i18n/ko.py
+++ b/gui/i18n/ko.py
@@ -565,6 +565,7 @@ STRINGS: dict[str, str] = {
     "model_sam3": "SAM3 — 말풍선 마스킹",
     "model_mit": "MIT — 만화 텍스트 마스킹",
     "model_pe": "PE-Core-L14-336 — 비전 인코더 (CMMD 검증 / DCW)",
+    "model_animadex": "AnimaDex — 캡션 캐릭터 / 작가 데이터베이스",
     # HuggingFace 인증 (모델 다이얼로그)
     "models_hf_token_placeholder": "HuggingFace 토큰을 붙여넣으세요 (hf_…)",
     "models_hf_authenticate": "인증",
@@ -578,6 +579,27 @@ STRINGS: dict[str, str] = {
     "models_hf_authenticating": "인증 중…",
     "models_hf_logged_in": "✓ {name} (으)로 로그인되었습니다.",
     "models_hf_login_failed": "인증 실패: {err}",
+    # AnimaDex 가져오기 (모델 다이얼로그)
+    "models_animadex_header": "AnimaDex 캡션 데이터베이스",
+    "models_animadex_token_placeholder": "AnimaDex export token을 붙여넣으세요",
+    "models_animadex_save_token": "토큰 저장",
+    "models_animadex_import": "CSV 다운로드",
+    "models_animadex_hint": (
+        "캡션 순서 교정에서 캐릭터, 작품, 작가 판정에 사용합니다. "
+        '<a href="https://animadex.net">animadex.net</a>에서 offline export '
+        "token을 만든 뒤 characters.csv와 artists.csv를 models/animadex/ "
+        "아래로 다운로드합니다."
+    ),
+    "models_animadex_present": "✓ AnimaDex CSV와 인덱스가 준비되어 있습니다.",
+    "models_animadex_missing": "AnimaDex CSV가 아직 다운로드되지 않았습니다.",
+    "models_animadex_token_empty": "먼저 토큰을 붙여넣거나 저장된 토큰을 준비하세요.",
+    "models_animadex_saving": "AnimaDex 토큰 저장 중…",
+    "models_animadex_token_saved": "✓ AnimaDex 토큰이 저장되었습니다.",
+    "models_animadex_importing": "AnimaDex CSV 다운로드 및 인덱스 생성 중…",
+    "models_animadex_import_done": (
+        "✓ AnimaDex 가져오기 완료: 캐릭터 {characters}개, 작가 {artists}개."
+    ),
+    "models_animadex_failed": "AnimaDex 가져오기 실패: {err}",
     # Update dialog
     "update_title": "anima_lora 업데이트",
     "update_warning": "업데이트는 GitHub에서 최신 릴리스를 받아 작업 트리를 덮어씁니다 "

--- a/gui/i18n/ko.py
+++ b/gui/i18n/ko.py
@@ -422,7 +422,16 @@ STRINGS: dict[str, str] = {
     ),
     "caption_autotag_error": "자동 태깅 실패: {err}",
     "caption_autotag_empty": "태거가 이 이미지에서 태그를 찾지 못했습니다.",
+    "caption_order_correct": "순서 교정",
+    "caption_order_correct_tooltip": (
+        "ANIMA 캡션 규칙에 맞게 인원수, 캐릭터, 작품, 작가, 일반 태그 순서를 "
+        "정리합니다. 적용 전 텍스트는 캡션 이력에 남습니다."
+    ),
+    "caption_order_correct_empty": "교정할 캡션이 없습니다.",
+    "caption_order_correct_no_change": "교정할 순서 변경이 없습니다.",
+    "caption_order_correct_failed": "캡션 순서 교정 실패: {err}",
     "caption_versions": "이력…",
+    "caption_history_reason_order_correct": "순서 교정 전",
     "caption_dirty_marker": " *",
     "caption_diff_stats": "(+{add} / −{rem})",
     "caption_diff_clean": "(변경 없음)",

--- a/gui/system_dialog.py
+++ b/gui/system_dialog.py
@@ -35,6 +35,16 @@ from gui.i18n import t
 from gui.process import kill_process_tree, setup_kill_safe
 from gui.theme import tok
 from gui.widgets import apply_variant
+from library.anima_prompt.animadex import (
+    ANIMADEX_DEFAULT_DATA_DIR,
+    ANIMADEX_INDEX_DIR_NAME,
+    AnimaDexDB,
+    AnimaDexImportClient,
+    AnimaDexImportError,
+    AnimaDexImportToken,
+    AnimaDexTokenStore,
+    resolve_import_token,
+)
 
 # (task-key, display-label-i18n-key, [paths-relative-to-ROOT-that-must-all-exist])
 # Status is "installed" iff every path resolves; otherwise "missing".
@@ -182,6 +192,67 @@ class _HFLoginThread(QThread):
         self.done.emit(result)
 
 
+class _AnimaDexImportThread(QThread):
+    """Save an AnimaDex token and optionally download/build the local CSV index."""
+
+    done = Signal(dict)
+
+    def __init__(
+        self,
+        *,
+        token: str = "",
+        import_csvs: bool = False,
+        parent=None,
+    ):
+        super().__init__(parent)
+        self._token = token.strip()
+        self._import_csvs = import_csvs
+
+    def run(self) -> None:  # noqa: D401 — Qt override
+        result = {
+            "ok": False,
+            "action": "import" if self._import_csvs else "save",
+            "error": "",
+        }
+        try:
+            token = (
+                AnimaDexImportToken(token=self._token)
+                if self._token
+                else resolve_import_token()
+            )
+            if self._token:
+                AnimaDexTokenStore.default().save(token)
+            if not self._import_csvs:
+                result["ok"] = True
+                self.done.emit(result)
+                return
+
+            data_dir = ROOT / ANIMADEX_DEFAULT_DATA_DIR
+            client = AnimaDexImportClient(site=token.site, token=token.token)
+            import_result = client.download_required_csvs(data_dir)
+            db = AnimaDexDB.from_csvs(
+                characters_csv=import_result.characters_csv,
+                artists_csv=import_result.artists_csv,
+            )
+            character_index, artist_index = db.write_jsonl(
+                data_dir / ANIMADEX_INDEX_DIR_NAME
+            )
+            result.update(
+                {
+                    "ok": True,
+                    "characters": str(import_result.characters_csv),
+                    "artists": str(import_result.artists_csv),
+                    "character_index": str(character_index),
+                    "artist_index": str(artist_index),
+                    "character_count": len(db.character_records),
+                    "artist_count": len(db.artist_records),
+                }
+            )
+        except (AnimaDexImportError, OSError, ValueError) as e:
+            result["error"] = str(e)
+        self.done.emit(result)
+
+
 class ModelsDialog(_StreamingDialog):
     """One row per model group: label · status · download button.
 
@@ -195,6 +266,7 @@ class ModelsDialog(_StreamingDialog):
         # (status_label, paths, button) — _after_finished refreshes every row after download-all.
         self._rows: list[tuple[QLabel, list[str], QPushButton]] = []
         self._login_thread: _HFLoginThread | None = None
+        self._animadex_thread: _AnimaDexImportThread | None = None
         super().__init__(t("models_title"), parent)
 
     def _build_actions(self, layout: QVBoxLayout) -> None:
@@ -220,6 +292,40 @@ class ModelsDialog(_StreamingDialog):
         hint.setStyleSheet(f"color:{tok('text_dim')};font-size:11px;margin-bottom:6px;")
         layout.addWidget(hint)
         self._refresh_auth_status()
+
+        animadex_header = QLabel(t("models_animadex_header"))
+        animadex_header.setStyleSheet("font-weight:bold;margin-top:8px;")
+        layout.addWidget(animadex_header)
+
+        animadex_row = QHBoxLayout()
+        self.animadex_token_edit = QLineEdit()
+        self.animadex_token_edit.setEchoMode(QLineEdit.Password)
+        self.animadex_token_edit.setPlaceholderText(
+            t("models_animadex_token_placeholder")
+        )
+        self.animadex_token_edit.returnPressed.connect(self._save_animadex_token)
+        animadex_row.addWidget(self.animadex_token_edit, 1)
+        self.animadex_save_btn = QPushButton(t("models_animadex_save_token"))
+        self.animadex_save_btn.clicked.connect(self._save_animadex_token)
+        animadex_row.addWidget(self.animadex_save_btn)
+        self.animadex_import_btn = QPushButton(t("models_animadex_import"))
+        apply_variant(self.animadex_import_btn, "info")
+        self.animadex_import_btn.clicked.connect(self._import_animadex)
+        animadex_row.addWidget(self.animadex_import_btn)
+        layout.addLayout(animadex_row)
+
+        self.animadex_status = QLabel()
+        self.animadex_status.setWordWrap(True)
+        layout.addWidget(self.animadex_status)
+
+        animadex_hint = QLabel(t("models_animadex_hint"))
+        animadex_hint.setWordWrap(True)
+        animadex_hint.setOpenExternalLinks(True)
+        animadex_hint.setStyleSheet(
+            f"color:{tok('text_dim')};font-size:11px;margin-bottom:6px;"
+        )
+        layout.addWidget(animadex_hint)
+        self._refresh_animadex_status()
 
         intro = QLabel(t("models_intro"))
         intro.setWordWrap(True)
@@ -263,6 +369,22 @@ class ModelsDialog(_StreamingDialog):
             row.addWidget(btn)
 
             layout.addLayout(row)
+
+        animadex_model_row = QHBoxLayout()
+        animadex_name = QLabel(t("model_animadex"))
+        animadex_name.setMinimumWidth(280)
+        animadex_model_row.addWidget(animadex_name)
+
+        self.animadex_model_status = QLabel()
+        self.animadex_model_status.setMinimumWidth(110)
+        animadex_model_row.addWidget(self.animadex_model_status)
+        animadex_model_row.addStretch()
+
+        self.animadex_model_btn = QPushButton()
+        self.animadex_model_btn.clicked.connect(self._import_animadex)
+        animadex_model_row.addWidget(self.animadex_model_btn)
+        layout.addLayout(animadex_model_row)
+        self._refresh_animadex_model_row()
 
     def _download(
         self,
@@ -318,11 +440,109 @@ class ModelsDialog(_StreamingDialog):
             )
             self.auth_status.setStyleSheet(f"color:{tok('err')};")
 
+    def _animadex_paths_present(self) -> bool:
+        data_dir = ROOT / ANIMADEX_DEFAULT_DATA_DIR
+        return all(
+            (data_dir / rel).is_file()
+            for rel in (
+                "import/characters.csv",
+                "import/artists.csv",
+                "index/character_index.jsonl",
+                "index/artist_index.jsonl",
+            )
+        )
+
+    def _refresh_animadex_status(self) -> None:
+        if self._animadex_paths_present():
+            self.animadex_status.setText(t("models_animadex_present"))
+            self.animadex_status.setStyleSheet(f"color:{tok('ok')};")
+        else:
+            self.animadex_status.setText(t("models_animadex_missing"))
+            self.animadex_status.setStyleSheet(f"color:{tok('text_dim')};")
+        self._refresh_animadex_model_row()
+
+    def _refresh_animadex_model_row(self) -> None:
+        if not hasattr(self, "animadex_model_status"):
+            return
+        installed = self._animadex_paths_present()
+        self.animadex_model_status.setText(
+            t("models_installed") if installed else t("models_missing")
+        )
+        self.animadex_model_status.setStyleSheet(
+            f"color:{tok('ok')};" if installed else f"color:{tok('err')};"
+        )
+        self.animadex_model_btn.setText(
+            t("models_redownload") if installed else t("models_download")
+        )
+
+    def _start_animadex_thread(self, *, import_csvs: bool) -> None:
+        token = self.animadex_token_edit.text().strip()
+        has_stored_token = False
+        if not token:
+            try:
+                has_stored_token = AnimaDexTokenStore.default().load() is not None
+            except AnimaDexImportError:
+                has_stored_token = False
+        if not token and (not import_csvs or not has_stored_token):
+            self.animadex_status.setText(t("models_animadex_token_empty"))
+            self.animadex_status.setStyleSheet(f"color:{tok('err')};")
+            return
+        if self._animadex_thread is not None and self._animadex_thread.isRunning():
+            return
+        self.animadex_save_btn.setEnabled(False)
+        self.animadex_import_btn.setEnabled(False)
+        if hasattr(self, "animadex_model_btn"):
+            self.animadex_model_btn.setEnabled(False)
+        self.animadex_status.setText(
+            t("models_animadex_importing")
+            if import_csvs
+            else t("models_animadex_saving")
+        )
+        self.animadex_status.setStyleSheet(f"color:{tok('text_dim')};")
+        self._animadex_thread = _AnimaDexImportThread(
+            token=token,
+            import_csvs=import_csvs,
+            parent=self,
+        )
+        self._animadex_thread.done.connect(self._on_animadex_result)
+        self._animadex_thread.start()
+
+    def _save_animadex_token(self) -> None:
+        self._start_animadex_thread(import_csvs=False)
+
+    def _import_animadex(self) -> None:
+        self._start_animadex_thread(import_csvs=True)
+
+    def _on_animadex_result(self, result: dict) -> None:
+        self.animadex_save_btn.setEnabled(True)
+        self.animadex_import_btn.setEnabled(True)
+        self.animadex_model_btn.setEnabled(True)
+        if result.get("ok"):
+            self.animadex_token_edit.clear()
+            if result.get("action") == "import":
+                self.animadex_status.setText(
+                    t(
+                        "models_animadex_import_done",
+                        characters=result.get("character_count", 0),
+                        artists=result.get("artist_count", 0),
+                    )
+                )
+            else:
+                self.animadex_status.setText(t("models_animadex_token_saved"))
+            self.animadex_status.setStyleSheet(f"color:{tok('ok')};font-weight:bold;")
+            self._refresh_animadex_model_row()
+            return
+        self.animadex_status.setText(
+            t("models_animadex_failed", err=result.get("error", ""))
+        )
+        self.animadex_status.setStyleSheet(f"color:{tok('err')};")
+
     def _set_busy(self, busy: bool) -> None:
         super()._set_busy(busy)
         self.all_btn.setEnabled(not busy)
         for _status, _paths, b in self._rows:
             b.setEnabled(not busy)
+        self.animadex_model_btn.setEnabled(not busy)
 
     def _after_finished(self, exit_code: int) -> None:
         # Refresh every row — download-models touches several groups in one run.
@@ -335,6 +555,7 @@ class ModelsDialog(_StreamingDialog):
                 f"color:{tok('ok')};" if installed else f"color:{tok('err')};"
             )
             btn.setText(t("models_redownload") if installed else t("models_download"))
+        self._refresh_animadex_model_row()
 
         if exit_code != 0:
             QMessageBox.warning(
@@ -353,6 +574,8 @@ class ModelsDialog(_StreamingDialog):
         # Without wait(), Qt warns about destroying a running QThread.
         if self._login_thread is not None and self._login_thread.isRunning():
             self._login_thread.wait(2000)
+        if self._animadex_thread is not None and self._animadex_thread.isRunning():
+            self._animadex_thread.wait(2000)
         super().closeEvent(ev)
 
 

--- a/gui/tabs/image_tab.py
+++ b/gui/tabs/image_tab.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import difflib
 import json
+import re
 import shutil
 import sys
 from datetime import datetime
@@ -2308,6 +2309,28 @@ class ImageViewerTab(DaemonJobMixin, LazyTabMixin, QWidget):
             self._caption_knowledge_base = load_knowledge_base(allow_missing=True)
         return self._caption_knowledge_base
 
+    def _caption_order_tag_setting(self, key: str) -> list[str]:
+        raw = get_setting(key, "")
+        if isinstance(raw, list):
+            parts = raw
+        else:
+            parts = re.split(r"[,\n]", str(raw))
+        return [str(part).strip() for part in parts if str(part).strip()]
+
+    def _caption_order_options(self) -> dict:
+        return {
+            "validate_artist_tags": bool(
+                get_setting("caption_validate_artist_tags", False)
+            ),
+            "insert_no_artist": bool(get_setting("caption_insert_no_artist", False)),
+            "artist_overrides": self._caption_order_tag_setting(
+                "caption_artist_overrides"
+            ),
+            "artist_exclusions": self._caption_order_tag_setting(
+                "caption_artist_exclusions"
+            ),
+        }
+
     def _apply_caption_order_correction(self) -> None:
         cp = self._current_caption_path
         if cp is None:
@@ -2323,6 +2346,7 @@ class ImageViewerTab(DaemonJobMixin, LazyTabMixin, QWidget):
                 old_text,
                 profile="caption",
                 knowledge_base=self._load_caption_knowledge_base(),
+                **self._caption_order_options(),
             )
         except Exception as e:
             QMessageBox.warning(
@@ -2350,6 +2374,7 @@ class ImageViewerTab(DaemonJobMixin, LazyTabMixin, QWidget):
             text,
             profile="caption",
             knowledge_base=self._load_caption_knowledge_base(),
+            **self._caption_order_options(),
         )
         return result.text if result.changed else None
 

--- a/gui/tabs/image_tab.py
+++ b/gui/tabs/image_tab.py
@@ -906,9 +906,17 @@ class ImageViewerTab(DaemonJobMixin, LazyTabMixin, QWidget):
         self.autotag_btn.setToolTip(t("caption_autotag_tooltip"))
         apply_variant(self.autotag_btn, "info")
         self.autotag_btn.clicked.connect(self._run_autotag)
-        self.correct_caption_btn = QPushButton(t("caption_order_correct"))
-        self.correct_caption_btn.setToolTip(t("caption_order_correct_tooltip"))
-        self.correct_caption_btn.clicked.connect(self._apply_caption_order_correction)
+        self.correct_caption_btn = self._make_button_with_menu(
+            t("caption_order_correct"),
+            t("caption_order_correct_tooltip"),
+            self._apply_caption_order_correction,
+            [
+                (
+                    t("caption_order_correct_all"),
+                    self._apply_caption_order_correction_all,
+                )
+            ],
+        )
         self.versions_btn = QPushButton(t("caption_versions"))
         self.versions_btn.clicked.connect(self._open_versions)
         cap_head.addWidget(self.save_btn)
@@ -2332,6 +2340,66 @@ class ImageViewerTab(DaemonJobMixin, LazyTabMixin, QWidget):
         self._set_caption_text(result.text)
         self._refresh_buttons()
         self._refresh_inline_diff()
+
+    def _correct_caption_text(self, text: str) -> str | None:
+        if not text.strip():
+            return None
+        from library.anima_prompt import correct_prompt
+
+        result = correct_prompt(
+            text,
+            profile="caption",
+            knowledge_base=self._load_caption_knowledge_base(),
+        )
+        return result.text if result.changed else None
+
+    def _apply_caption_order_correction_all(self) -> None:
+        if self._current_dir is None:
+            return
+        if not self._confirm_discard_if_dirty():
+            return
+        captions = [p.with_suffix(".txt") for p in self._all_images]
+        changed = 0
+        skipped_missing = 0
+        failed: list[str] = []
+        for cp in captions:
+            if not cp.is_file():
+                skipped_missing += 1
+                continue
+            try:
+                old_text = cp.read_text(encoding="utf-8")
+                new_text = self._correct_caption_text(old_text)
+                if new_text is None:
+                    continue
+                _append_history(cp, old_text, reason="order_correction")
+                cp.write_text(new_text, encoding="utf-8")
+                changed += 1
+            except Exception as e:
+                failed.append(f"{cp.name}: {e}")
+
+        if (
+            self._current_caption_path is not None
+            and self._current_caption_path.is_file()
+        ):
+            text = self._current_caption_path.read_text(encoding="utf-8")
+            self._disk_text = text
+            self._set_caption_text(text)
+            self._refresh_buttons()
+            self._refresh_inline_diff()
+
+        message = t(
+            "caption_order_correct_all_done",
+            changed=changed,
+            skipped=skipped_missing,
+        )
+        if failed:
+            QMessageBox.warning(
+                self,
+                t("caption_order_correct"),
+                message + "\n\n" + "\n".join(failed[:20]),
+            )
+        else:
+            QMessageBox.information(self, t("caption_order_correct"), message)
 
     def _save(self) -> None:
         cp = self._current_caption_path

--- a/gui/tabs/image_tab.py
+++ b/gui/tabs/image_tab.py
@@ -379,10 +379,19 @@ def _read_history(caption_path: Path) -> list[dict]:
     return out
 
 
-def _append_history(caption_path: Path, prev_text: str) -> None:
+def _append_history(
+    caption_path: Path, prev_text: str, *, reason: str = "save"
+) -> None:
     """Append the previous on-disk text as a history entry."""
     hp = _history_path(caption_path)
-    entry = {"ts": datetime.now().isoformat(timespec="seconds"), "text": prev_text}
+    history = _read_history(caption_path)
+    if history and history[-1].get("text") == prev_text:
+        return
+    entry = {
+        "ts": datetime.now().isoformat(timespec="seconds"),
+        "text": prev_text,
+        "reason": reason,
+    }
     with hp.open("a", encoding="utf-8") as f:
         f.write(json.dumps(entry, ensure_ascii=False) + "\n")
 
@@ -601,7 +610,10 @@ class CaptionVersionsDialog(QDialog):
             self.list.setEnabled(False)
         else:
             for entry in self._history:
-                self.list.addItem(entry["ts"])
+                label = str(entry["ts"])
+                if entry.get("reason") == "order_correction":
+                    label += " · " + t("caption_history_reason_order_correct")
+                self.list.addItem(label)
         self.list.currentRowChanged.connect(self._show_diff)
         sp.addWidget(self.list)
 
@@ -674,6 +686,7 @@ class ImageViewerTab(DaemonJobMixin, LazyTabMixin, QWidget):
         self._current_caption_path: Path | None = None
         self._disk_text: str = ""  # last value seen on disk (for diff baseline)
         self._suspend_dirty = False  # while we set text programmatically
+        self._caption_knowledge_base = None
         # Resident autotag worker: a torch QProcess holding the tagger model so
         # consecutive clicks skip the reload; torn down before any other GPU
         # work frees the card. See _run_autotag / _kill_tagger_worker.
@@ -893,11 +906,15 @@ class ImageViewerTab(DaemonJobMixin, LazyTabMixin, QWidget):
         self.autotag_btn.setToolTip(t("caption_autotag_tooltip"))
         apply_variant(self.autotag_btn, "info")
         self.autotag_btn.clicked.connect(self._run_autotag)
+        self.correct_caption_btn = QPushButton(t("caption_order_correct"))
+        self.correct_caption_btn.setToolTip(t("caption_order_correct_tooltip"))
+        self.correct_caption_btn.clicked.connect(self._apply_caption_order_correction)
         self.versions_btn = QPushButton(t("caption_versions"))
         self.versions_btn.clicked.connect(self._open_versions)
         cap_head.addWidget(self.save_btn)
         cap_head.addWidget(self.revert_btn)
         cap_head.addWidget(self.autotag_btn)
+        cap_head.addWidget(self.correct_caption_btn)
         cap_head.addWidget(self.versions_btn)
         rl.addLayout(cap_head)
 
@@ -2249,6 +2266,10 @@ class ImageViewerTab(DaemonJobMixin, LazyTabMixin, QWidget):
         # Versions button is enabled whenever there's a caption file context;
         # the dialog itself shows "(no prior versions)" when empty.
         self.versions_btn.setEnabled(self._current_caption_path is not None)
+        self.correct_caption_btn.setEnabled(
+            self._current_caption_path is not None
+            and bool(self.cap.toPlainText().strip())
+        )
 
     def _refresh_inline_diff(self) -> None:
         """Highlight inserted spans (vs disk) directly in the editor."""
@@ -2271,6 +2292,46 @@ class ImageViewerTab(DaemonJobMixin, LazyTabMixin, QWidget):
             es.format = fmt
             sels.append(es)
         self.cap.setExtraSelections(sels)
+
+    def _load_caption_knowledge_base(self):
+        if self._caption_knowledge_base is None:
+            from library.anima_prompt import load_knowledge_base
+
+            self._caption_knowledge_base = load_knowledge_base(allow_missing=True)
+        return self._caption_knowledge_base
+
+    def _apply_caption_order_correction(self) -> None:
+        cp = self._current_caption_path
+        if cp is None:
+            return
+        old_text = self.cap.toPlainText()
+        if not old_text.strip():
+            QMessageBox.information(self, "", t("caption_order_correct_empty"))
+            return
+        try:
+            from library.anima_prompt import correct_prompt
+
+            result = correct_prompt(
+                old_text,
+                profile="caption",
+                knowledge_base=self._load_caption_knowledge_base(),
+            )
+        except Exception as e:
+            QMessageBox.warning(
+                self, t("error"), t("caption_order_correct_failed", err=str(e))
+            )
+            return
+        if not result.changed:
+            QMessageBox.information(self, "", t("caption_order_correct_no_change"))
+            return
+        try:
+            _append_history(cp, old_text, reason="order_correction")
+        except OSError as e:
+            QMessageBox.warning(self, t("error"), t("caption_save_failed", err=str(e)))
+            return
+        self._set_caption_text(result.text)
+        self._refresh_buttons()
+        self._refresh_inline_diff()
 
     def _save(self) -> None:
         cp = self._current_caption_path

--- a/library/anima_prompt/README.md
+++ b/library/anima_prompt/README.md
@@ -68,7 +68,7 @@ Environment variables:
 
 ```powershell
 uv run python scripts/anima_prompt.py build-index --tag-csv tags.csv --output tag_index.jsonl
-uv run python scripts/anima_prompt.py build-animadex-index --characters-csv characters.csv --artists-csv artists.csv --output-dir data/animadex
+uv run python scripts/anima_prompt.py build-animadex-index --characters-csv characters.csv --artists-csv artists.csv --output-dir models/animadex/index
 uv run python scripts/anima_prompt.py animadex-save-token
 uv run python scripts/anima_prompt.py animadex-import --build-index
 uv run python scripts/anima_prompt.py check --text "long hair, 1girl" --tag-csv tags.csv
@@ -107,12 +107,12 @@ Default local paths:
 
 - Token: `%APPDATA%\anima_prompt\animadex_import_token.json` on Windows, or
   `~/.config/anima_prompt/animadex_import_token.json` on other OSes
-- CSV: `data/animadex/import/characters.csv`,
-  `data/animadex/import/artists.csv`
-- Index: `data/animadex/index/character_index.jsonl`,
-  `data/animadex/index/artist_index.jsonl`
+- CSV: `models/animadex/import/characters.csv`,
+  `models/animadex/import/artists.csv`
+- Index: `models/animadex/index/character_index.jsonl`,
+  `models/animadex/index/artist_index.jsonl`
 
-`data/animadex/` is ignored by git. Do not commit downloaded CSVs or tokens.
+`models/animadex/` is ignored by git. Do not commit downloaded CSVs or tokens.
 
 AnimaDex CSV fields used by the prompt core:
 

--- a/library/anima_prompt/README.md
+++ b/library/anima_prompt/README.md
@@ -1,0 +1,141 @@
+# ANIMA Prompt Correction Core
+
+Dependency-light prompt/caption correction helpers for ANIMA-style tag order.
+
+This package is designed so it can later be split into a standalone repository.
+It does not import ComfyUI, torch, model loading code, or taggers.
+
+Detailed design and workflow documentation:
+[`docs/anima_prompt.md`](../../docs/anima_prompt.md)
+
+## MVP Scope
+
+- Danbooru-style comma-separated prompt parsing
+- newline-preserving caption parsing
+- tag normalization
+- local tag DB lookup
+- category classification
+- ANIMA ordering
+- correction report data
+- check/fix CLI skeleton
+
+## Ordering
+
+The default ordering is:
+
+```text
+quality / meta / year / safety
+-> character count / person type
+-> character
+-> series / copyright
+-> artist
+-> general tags
+-> unknown tags
+```
+
+Example:
+
+```text
+masterpiece, best quality, newest, safe,
+1girl,
+hatsune miku,
+vocaloid,
+@artist_name,
+aqua eyes, twintails, detached sleeves
+```
+
+## Data Sources
+
+Local data is preferred. Automatic remote downloads are intentionally not part
+of the MVP.
+
+Resolution order:
+
+1. CLI argument
+2. environment variable
+3. workspace-local default filename
+
+Environment variables:
+
+- `ANIMA_PROMPT_TAG_CSV`
+- `ANIMA_PROMPT_TAG_INDEX`
+- `ANIMADEX_CHARACTERS_CSV`
+- `ANIMADEX_ARTISTS_CSV`
+- `ANIMADEX_CHARACTER_INDEX`
+- `ANIMADEX_ARTIST_INDEX`
+
+## CLI
+
+```powershell
+uv run python scripts/anima_prompt.py build-index --tag-csv tags.csv --output tag_index.jsonl
+uv run python scripts/anima_prompt.py build-animadex-index --characters-csv characters.csv --artists-csv artists.csv --output-dir data/animadex
+uv run python scripts/anima_prompt.py animadex-save-token
+uv run python scripts/anima_prompt.py animadex-import --build-index
+uv run python scripts/anima_prompt.py check --text "long hair, 1girl" --tag-csv tags.csv
+uv run python scripts/anima_prompt.py fix --text "long_hair, @artist, 1girl" --tag-csv tags.csv
+```
+
+### AnimaDex
+
+AnimaDex is expected to be the primary source for character and artist data.
+This package does not depend on the full AnimaDex Flask/SQLite app. It reads
+only local CSV exports:
+
+- `characters.csv`
+- `artists.csv`
+
+The official AnimaDex import flow is:
+
+1. Open `animadex.net`.
+2. Create a personal export token from Account -> Offline dataset export.
+3. Save the token outside the repository:
+
+   ```powershell
+   uv run python scripts/anima_prompt.py animadex-save-token
+   ```
+
+4. Download the CSV files for local testing:
+
+   ```powershell
+   uv run python scripts/anima_prompt.py animadex-import --build-index
+   ```
+
+The official site import uses `ANIMADEX_IMPORT_TOKEN`, `/api/export/manifest`,
+and the `X-Export-Token` header.
+
+Default local paths:
+
+- Token: `%APPDATA%\anima_prompt\animadex_import_token.json` on Windows, or
+  `~/.config/anima_prompt/animadex_import_token.json` on other OSes
+- CSV: `data/animadex/import/characters.csv`,
+  `data/animadex/import/artists.csv`
+- Index: `data/animadex/index/character_index.jsonl`,
+  `data/animadex/index/artist_index.jsonl`
+
+`data/animadex/` is ignored by git. Do not commit downloaded CSVs or tokens.
+
+AnimaDex CSV fields used by the prompt core:
+
+- Characters: `character`, `copyright`, `trigger`, `core_tags`, `count`, `url`
+- Artists: `artist`, `trigger`, `count`, `url`
+
+`trigger` is used to connect character and copyright text. `core_tags` are used
+as known character trait tags, and person tags such as `1girl`, `1boy`,
+`1other`, and `no humans` are ordered before character tags.
+
+## API
+
+```python
+from library.anima_prompt import correct_prompt, load_knowledge_base
+
+kb = load_knowledge_base(tag_csv="tags.csv")
+result = correct_prompt(
+    "1girl, gotoh hitori, bocchi the rock!, long hair",
+    profile="prompt",
+    knowledge_base=kb,
+)
+
+print(result.text)
+print(result.warnings)
+print(result.unknown_tags)
+```

--- a/library/anima_prompt/__init__.py
+++ b/library/anima_prompt/__init__.py
@@ -1,0 +1,44 @@
+"""ANIMA prompt/caption correction helpers.
+
+This package is intentionally dependency-light. It does not import torch,
+ComfyUI, model code, or taggers, so the same core can be reused by CLI tools
+and future UI nodes.
+"""
+
+from .animadex import (
+    AnimaDexArtist,
+    AnimaDexCharacter,
+    AnimaDexDB,
+    AnimaDexImportClient,
+    AnimaDexImportError,
+    AnimaDexImportToken,
+    AnimaDexTokenStore,
+)
+from .correction import correct_prompt, inspect_prompt
+from .knowledge import (
+    GeneralTagDB,
+    KnowledgeBaseNotFound,
+    PromptKnowledgeBase,
+    load_knowledge_base,
+)
+from .models import CorrectionResult, ParsedPrompt, TagInfo, TagToken
+
+__all__ = [
+    "AnimaDexArtist",
+    "AnimaDexCharacter",
+    "AnimaDexDB",
+    "AnimaDexImportClient",
+    "AnimaDexImportError",
+    "AnimaDexImportToken",
+    "AnimaDexTokenStore",
+    "CorrectionResult",
+    "GeneralTagDB",
+    "KnowledgeBaseNotFound",
+    "ParsedPrompt",
+    "PromptKnowledgeBase",
+    "TagInfo",
+    "TagToken",
+    "correct_prompt",
+    "inspect_prompt",
+    "load_knowledge_base",
+]

--- a/library/anima_prompt/animadex.py
+++ b/library/anima_prompt/animadex.py
@@ -26,7 +26,7 @@ ANIMADEX_DEFAULT_SITE = "https://animadex.net"
 ANIMADEX_MANIFEST_PATH = "/api/export/manifest"
 ANIMADEX_EXPORT_TOKEN_HEADER = "X-Export-Token"
 ANIMADEX_IMPORT_USER_AGENT = "animadex-import/1"
-ANIMADEX_DEFAULT_DATA_DIR = Path("data") / "animadex"
+ANIMADEX_DEFAULT_DATA_DIR = Path("models") / "animadex"
 ANIMADEX_IMPORT_DIR_NAME = "import"
 ANIMADEX_INDEX_DIR_NAME = "index"
 

--- a/library/anima_prompt/animadex.py
+++ b/library/anima_prompt/animadex.py
@@ -1,0 +1,485 @@
+"""Lightweight AnimaDex CSV loading for prompt correction.
+
+The full AnimaDex app owns account login, export tokens, SQLite storage, and
+thumbnail import. This module intentionally reads only local ``characters.csv``
+and ``artists.csv`` exports so the prompt core can stay dependency-light.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+import stat
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from .normalize import lookup_key, normalize_tag
+
+ANIMADEX_IMPORT_TOKEN_ENV = "ANIMADEX_IMPORT_TOKEN"
+ANIMADEX_IMPORT_TOKEN_FILE_ENV = "ANIMADEX_IMPORT_TOKEN_FILE"
+ANIMADEX_DEFAULT_SITE = "https://animadex.net"
+ANIMADEX_MANIFEST_PATH = "/api/export/manifest"
+ANIMADEX_EXPORT_TOKEN_HEADER = "X-Export-Token"
+ANIMADEX_IMPORT_USER_AGENT = "animadex-import/1"
+ANIMADEX_DEFAULT_DATA_DIR = Path("data") / "animadex"
+ANIMADEX_IMPORT_DIR_NAME = "import"
+ANIMADEX_INDEX_DIR_NAME = "index"
+
+GENDER_TAGS = frozenset({"1boy", "1girl", "1other", "no humans"})
+
+
+class AnimaDexImportError(RuntimeError):
+    """Raised when AnimaDex export import cannot complete."""
+
+
+def default_token_path() -> Path:
+    configured = os.environ.get(ANIMADEX_IMPORT_TOKEN_FILE_ENV)
+    if configured:
+        return Path(configured)
+    if os.name == "nt":
+        root = os.environ.get("APPDATA")
+        if root:
+            return Path(root) / "anima_prompt" / "animadex_import_token.json"
+    return Path.home() / ".config" / "anima_prompt" / "animadex_import_token.json"
+
+
+@dataclass(frozen=True)
+class AnimaDexImportToken:
+    token: str
+    site: str = ANIMADEX_DEFAULT_SITE
+
+    def to_json(self) -> dict[str, str]:
+        return {"token": self.token, "site": self.site}
+
+    @classmethod
+    def from_json(cls, data: dict[str, object]) -> "AnimaDexImportToken":
+        token = str(data.get("token") or "").strip()
+        if not token:
+            raise AnimaDexImportError("Stored AnimaDex token file is missing token.")
+        site = str(data.get("site") or ANIMADEX_DEFAULT_SITE).strip()
+        return cls(token=token, site=site)
+
+
+@dataclass
+class AnimaDexTokenStore:
+    path: Path
+
+    @classmethod
+    def default(cls) -> "AnimaDexTokenStore":
+        return cls(default_token_path())
+
+    def load(self) -> AnimaDexImportToken | None:
+        if not self.path.is_file():
+            return None
+        try:
+            data = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as e:
+            raise AnimaDexImportError(f"Could not read AnimaDex token file: {e}") from e
+        if not isinstance(data, dict):
+            raise AnimaDexImportError("Stored AnimaDex token file is not a JSON object.")
+        return AnimaDexImportToken.from_json(data)
+
+    def save(self, token: AnimaDexImportToken) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(
+            json.dumps(token.to_json(), ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        try:
+            self.path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+        except OSError:
+            pass
+
+
+@dataclass(frozen=True)
+class AnimaDexImportResult:
+    characters_csv: Path
+    artists_csv: Path
+    manifest: dict[str, object]
+
+
+def resolve_import_token(
+    *,
+    token: str | None = None,
+    token_file: str | os.PathLike | None = None,
+) -> AnimaDexImportToken:
+    if token:
+        return AnimaDexImportToken(token=token.strip())
+    env_token = os.environ.get(ANIMADEX_IMPORT_TOKEN_ENV)
+    if env_token:
+        return AnimaDexImportToken(token=env_token.strip())
+    store = AnimaDexTokenStore(Path(token_file)) if token_file else AnimaDexTokenStore.default()
+    stored = store.load()
+    if stored is None:
+        raise AnimaDexImportError(
+            "No AnimaDex export token. Pass --token, set "
+            f"{ANIMADEX_IMPORT_TOKEN_ENV}, or run animadex-save-token."
+        )
+    return stored
+
+
+@dataclass
+class AnimaDexImportClient:
+    site: str = ANIMADEX_DEFAULT_SITE
+    token: str = ""
+    timeout: float = 60.0
+    opener: object = urlopen
+
+    def fetch_manifest(self, *, full: bool = False) -> dict[str, object]:
+        query = f"?{urlencode({'full': '1'})}" if full else ""
+        url = self.site.rstrip("/") + ANIMADEX_MANIFEST_PATH + query
+        request = Request(
+            url,
+            headers={
+                ANIMADEX_EXPORT_TOKEN_HEADER: self.token,
+                "User-Agent": ANIMADEX_IMPORT_USER_AGENT,
+            },
+            method="GET",
+        )
+        data = self._open_bytes(request)
+        try:
+            manifest = json.loads(data.decode("utf-8"))
+        except json.JSONDecodeError as e:
+            raise AnimaDexImportError(f"AnimaDex manifest was not JSON: {e}") from e
+        if not isinstance(manifest, dict):
+            raise AnimaDexImportError("AnimaDex manifest was not a JSON object.")
+        return manifest
+
+    def download_required_csvs(
+        self,
+        data_dir: str | os.PathLike = ANIMADEX_DEFAULT_DATA_DIR,
+        *,
+        full: bool = False,
+    ) -> AnimaDexImportResult:
+        manifest = self.fetch_manifest(full=full)
+        csv_manifest = manifest.get("csv")
+        if not isinstance(csv_manifest, dict):
+            raise AnimaDexImportError("AnimaDex manifest is missing csv entries.")
+
+        characters_url = str(csv_manifest.get("characters") or "")
+        artists_url = str(csv_manifest.get("artists") or "")
+        if not characters_url or not artists_url:
+            raise AnimaDexImportError(
+                "AnimaDex manifest must include csv.characters and csv.artists."
+            )
+
+        import_dir = Path(data_dir) / ANIMADEX_IMPORT_DIR_NAME
+        import_dir.mkdir(parents=True, exist_ok=True)
+        characters_path = import_dir / "characters.csv"
+        artists_path = import_dir / "artists.csv"
+        characters_path.write_bytes(self._download_url(characters_url))
+        artists_path.write_bytes(self._download_url(artists_url))
+        return AnimaDexImportResult(
+            characters_csv=characters_path,
+            artists_csv=artists_path,
+            manifest=manifest,
+        )
+
+    def _open_bytes(self, request: Request) -> bytes:
+        try:
+            with self.opener(request, timeout=self.timeout) as response:
+                return response.read()
+        except HTTPError as e:
+            detail = e.read().decode("utf-8", errors="replace")
+            raise AnimaDexImportError(f"AnimaDex HTTP {e.code}: {detail}") from e
+        except URLError as e:
+            raise AnimaDexImportError(f"Could not reach AnimaDex: {e.reason}") from e
+
+    def _download_url(self, url: str) -> bytes:
+        request = Request(
+            url,
+            headers={"User-Agent": ANIMADEX_IMPORT_USER_AGENT},
+            method="GET",
+        )
+        return self._open_bytes(request)
+
+
+def _parse_int(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(str(value).replace(",", "").strip())
+    except ValueError:
+        return None
+
+
+def _field(row: dict[str, str], name: str) -> str:
+    lowered = {str(k).strip().lower(): v for k, v in row.items()}
+    value = lowered.get(name)
+    return str(value).strip() if value else ""
+
+
+def parse_core_tags(value: str) -> tuple[str, ...]:
+    return tuple(
+        normalize_tag(part)
+        for part in value.split(",")
+        if normalize_tag(part)
+    )
+
+
+def split_trigger(trigger: str) -> tuple[str, str]:
+    """Split an AnimaDex character trigger into character and copyright text."""
+
+    parts = [normalize_tag(part) for part in trigger.split(",", 1)]
+    if not parts:
+        return "", ""
+    if len(parts) == 1:
+        return parts[0], ""
+    return parts[0], parts[1].strip()
+
+
+@dataclass(frozen=True)
+class AnimaDexCharacter:
+    character: str
+    copyright: str
+    trigger: str
+    core_tags: tuple[str, ...] = ()
+    count: int | None = None
+    url: str = ""
+    trigger_character: str = ""
+    trigger_copyright: str = ""
+
+    @property
+    def person_tags(self) -> tuple[str, ...]:
+        return tuple(tag for tag in self.core_tags if tag in GENDER_TAGS)
+
+    @property
+    def trait_tags(self) -> tuple[str, ...]:
+        return tuple(tag for tag in self.core_tags if tag not in GENDER_TAGS)
+
+
+@dataclass(frozen=True)
+class AnimaDexArtist:
+    artist: str
+    trigger: str
+    count: int | None = None
+    url: str = ""
+
+
+def parse_character_row(row: dict[str, str]) -> AnimaDexCharacter | None:
+    character = lookup_key(_field(row, "character"))
+    copyright_tag = lookup_key(_field(row, "copyright"))
+    trigger = _field(row, "trigger")
+    trigger_character, trigger_copyright = split_trigger(trigger)
+    core_tags = parse_core_tags(_field(row, "core_tags"))
+
+    if not character and not trigger_character:
+        return None
+
+    return AnimaDexCharacter(
+        character=character,
+        copyright=copyright_tag,
+        trigger=normalize_tag(trigger),
+        core_tags=core_tags,
+        count=_parse_int(_field(row, "count")),
+        url=_field(row, "url"),
+        trigger_character=trigger_character,
+        trigger_copyright=trigger_copyright,
+    )
+
+
+def parse_artist_row(row: dict[str, str]) -> AnimaDexArtist | None:
+    artist = lookup_key(_field(row, "artist"))
+    trigger = normalize_tag(_field(row, "trigger") or artist)
+    if not artist and not trigger:
+        return None
+    return AnimaDexArtist(
+        artist=artist,
+        trigger=trigger,
+        count=_parse_int(_field(row, "count")),
+        url=_field(row, "url"),
+    )
+
+
+@dataclass
+class AnimaDexDB:
+    characters: set[str] = field(default_factory=set)
+    copyrights: set[str] = field(default_factory=set)
+    artists: set[str] = field(default_factory=set)
+    core_tags: set[str] = field(default_factory=set)
+    character_to_copyright: dict[str, str] = field(default_factory=dict)
+    character_core_tags: dict[str, tuple[str, ...]] = field(default_factory=dict)
+    character_records: dict[str, AnimaDexCharacter] = field(default_factory=dict)
+    artist_records: dict[str, AnimaDexArtist] = field(default_factory=dict)
+
+    @classmethod
+    def from_csvs(
+        cls,
+        *,
+        characters_csv: str | Path | None = None,
+        artists_csv: str | Path | None = None,
+    ) -> "AnimaDexDB":
+        db = cls()
+        if characters_csv and Path(characters_csv).is_file():
+            db.add_characters(read_characters_csv(characters_csv))
+        if artists_csv and Path(artists_csv).is_file():
+            db.add_artists(read_artists_csv(artists_csv))
+        return db
+
+    @classmethod
+    def from_jsonl(
+        cls,
+        *,
+        character_index: str | Path | None = None,
+        artist_index: str | Path | None = None,
+    ) -> "AnimaDexDB":
+        db = cls()
+        if character_index and Path(character_index).is_file():
+            records = []
+            with Path(character_index).open("r", encoding="utf-8") as f:
+                for line in f:
+                    if line.strip():
+                        data = json.loads(line)
+                        records.append(
+                            AnimaDexCharacter(
+                                character=str(data.get("character") or ""),
+                                copyright=str(data.get("copyright") or ""),
+                                trigger=str(data.get("trigger") or ""),
+                                core_tags=tuple(data.get("core_tags") or ()),
+                                count=data.get("count"),
+                                url=str(data.get("url") or ""),
+                                trigger_character=str(
+                                    data.get("trigger_character") or ""
+                                ),
+                                trigger_copyright=str(
+                                    data.get("trigger_copyright") or ""
+                                ),
+                            )
+                        )
+            db.add_characters(records)
+        if artist_index and Path(artist_index).is_file():
+            records = []
+            with Path(artist_index).open("r", encoding="utf-8") as f:
+                for line in f:
+                    if line.strip():
+                        data = json.loads(line)
+                        records.append(
+                            AnimaDexArtist(
+                                artist=str(data.get("artist") or ""),
+                                trigger=str(data.get("trigger") or ""),
+                                count=data.get("count"),
+                                url=str(data.get("url") or ""),
+                            )
+                        )
+            db.add_artists(records)
+        return db
+
+    def add_characters(self, records: Iterable[AnimaDexCharacter]) -> None:
+        for record in records:
+            names = {
+                lookup_key(record.character),
+                lookup_key(record.trigger_character),
+            }
+            names.discard("")
+            self.characters.update(names)
+
+            copyrights = {
+                lookup_key(record.copyright),
+                lookup_key(record.trigger_copyright),
+            }
+            copyrights.discard("")
+            self.copyrights.update(copyrights)
+
+            self.core_tags.update(record.core_tags)
+            canonical = lookup_key(record.trigger_character or record.character)
+            if canonical:
+                self.character_records[canonical] = record
+                self.character_core_tags[canonical] = record.core_tags
+                copyright_tag = lookup_key(
+                    record.trigger_copyright or record.copyright
+                )
+                if copyright_tag:
+                    self.character_to_copyright[canonical] = copyright_tag
+
+    def add_artists(self, records: Iterable[AnimaDexArtist]) -> None:
+        for record in records:
+            names = {lookup_key(record.artist), lookup_key(record.trigger)}
+            names.discard("")
+            self.artists.update(names)
+            canonical = lookup_key(record.trigger or record.artist)
+            if canonical:
+                self.artist_records[canonical] = record
+
+    def write_jsonl(self, output_dir: str | Path) -> tuple[Path, Path]:
+        out = Path(output_dir)
+        out.mkdir(parents=True, exist_ok=True)
+        character_path = out / "character_index.jsonl"
+        artist_path = out / "artist_index.jsonl"
+        write_character_index(character_path, self.character_records.values())
+        write_artist_index(artist_path, self.artist_records.values())
+        return character_path, artist_path
+
+
+def read_characters_csv(path: str | Path) -> list[AnimaDexCharacter]:
+    records: list[AnimaDexCharacter] = []
+    with Path(path).open("r", encoding="utf-8-sig", newline="") as f:
+        for row in csv.DictReader(f):
+            record = parse_character_row(row)
+            if record is not None:
+                records.append(record)
+    return records
+
+
+def read_artists_csv(path: str | Path) -> list[AnimaDexArtist]:
+    records: list[AnimaDexArtist] = []
+    with Path(path).open("r", encoding="utf-8-sig", newline="") as f:
+        for row in csv.DictReader(f):
+            record = parse_artist_row(row)
+            if record is not None:
+                records.append(record)
+    return records
+
+
+def write_character_index(
+    path: str | Path,
+    records: Iterable[AnimaDexCharacter],
+) -> None:
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with out.open("w", encoding="utf-8", newline="\n") as f:
+        for record in sorted(records, key=lambda item: item.character):
+            f.write(
+                json.dumps(
+                    {
+                        "character": record.character,
+                        "copyright": record.copyright,
+                        "trigger": record.trigger,
+                        "trigger_character": record.trigger_character,
+                        "trigger_copyright": record.trigger_copyright,
+                        "core_tags": list(record.core_tags),
+                        "count": record.count,
+                        "url": record.url,
+                    },
+                    ensure_ascii=False,
+                    sort_keys=True,
+                )
+                + "\n"
+            )
+
+
+def write_artist_index(
+    path: str | Path,
+    records: Iterable[AnimaDexArtist],
+) -> None:
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with out.open("w", encoding="utf-8", newline="\n") as f:
+        for record in sorted(records, key=lambda item: item.artist):
+            f.write(
+                json.dumps(
+                    {
+                        "artist": record.artist,
+                        "trigger": record.trigger,
+                        "count": record.count,
+                        "url": record.url,
+                    },
+                    ensure_ascii=False,
+                    sort_keys=True,
+                )
+                + "\n"
+            )

--- a/library/anima_prompt/cli.py
+++ b/library/anima_prompt/cli.py
@@ -1,0 +1,215 @@
+"""CLI for ANIMA prompt/caption inspection and correction."""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import sys
+from pathlib import Path
+
+from .animadex import (
+    ANIMADEX_DEFAULT_DATA_DIR,
+    ANIMADEX_INDEX_DIR_NAME,
+    AnimaDexDB,
+    AnimaDexImportClient,
+    AnimaDexImportError,
+    AnimaDexImportToken,
+    AnimaDexTokenStore,
+    default_token_path,
+    resolve_import_token,
+)
+from .correction import correct_prompt, inspect_prompt
+from .knowledge import GeneralTagDB, KnowledgeBaseNotFound, load_knowledge_base
+
+
+def _load_input(args) -> str:
+    if args.text is not None:
+        return args.text
+    if args.file:
+        return Path(args.file).read_text(encoding="utf-8")
+    return sys.stdin.read()
+
+
+def _add_db_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--tag-csv", default=None)
+    parser.add_argument("--tag-index", default=None)
+    parser.add_argument("--animadex-characters-csv", default=None)
+    parser.add_argument("--animadex-artists-csv", default=None)
+    parser.add_argument("--animadex-character-index", default=None)
+    parser.add_argument("--animadex-artist-index", default=None)
+
+
+def _load_kb(args):
+    return load_knowledge_base(
+        tag_csv=args.tag_csv,
+        tag_index=args.tag_index,
+        animadex_characters_csv=args.animadex_characters_csv,
+        animadex_artists_csv=args.animadex_artists_csv,
+        animadex_character_index=args.animadex_character_index,
+        animadex_artist_index=args.animadex_artist_index,
+    )
+
+
+def cmd_build_index(args) -> int:
+    db = GeneralTagDB.from_csv(args.tag_csv)
+    db.write_jsonl(args.output)
+    print(f"wrote {len(db.tags)} tags to {args.output}")
+    return 0
+
+
+def cmd_build_animadex_index(args) -> int:
+    db = AnimaDexDB.from_csvs(
+        characters_csv=args.characters_csv,
+        artists_csv=args.artists_csv,
+    )
+    character_path, artist_path = db.write_jsonl(args.output_dir)
+    print(f"wrote {len(db.character_records)} characters to {character_path}")
+    print(f"wrote {len(db.artist_records)} artists to {artist_path}")
+    return 0
+
+
+def cmd_animadex_save_token(args) -> int:
+    token = args.token or getpass.getpass("AnimaDex export token: ")
+    token = token.strip()
+    if not token:
+        print("empty token", file=sys.stderr)
+        return 2
+    store = AnimaDexTokenStore(
+        Path(args.token_file) if args.token_file else default_token_path()
+    )
+    store.save(AnimaDexImportToken(token=token, site=args.site))
+    print(f"token saved to {store.path}")
+    return 0
+
+
+def cmd_animadex_import(args) -> int:
+    try:
+        import_token = resolve_import_token(
+            token=args.token,
+            token_file=args.token_file,
+        )
+        site = args.site or import_token.site
+        client = AnimaDexImportClient(site=site, token=import_token.token)
+        output_dir = Path(args.output_dir)
+        result = client.download_required_csvs(output_dir, full=args.full)
+        if args.save_token:
+            store = AnimaDexTokenStore(
+                Path(args.token_file) if args.token_file else default_token_path()
+            )
+            store.save(AnimaDexImportToken(token=import_token.token, site=site))
+    except AnimaDexImportError as e:
+        print(str(e), file=sys.stderr)
+        return 2
+
+    print(f"characters: {result.characters_csv}")
+    print(f"artists: {result.artists_csv}")
+    if args.build_index:
+        db = AnimaDexDB.from_csvs(
+            characters_csv=result.characters_csv,
+            artists_csv=result.artists_csv,
+        )
+        index_dir = Path(args.index_dir) if args.index_dir else output_dir / ANIMADEX_INDEX_DIR_NAME
+        character_path, artist_path = db.write_jsonl(index_dir)
+        print(f"character index: {character_path}")
+        print(f"artist index: {artist_path}")
+    return 0
+
+
+def cmd_check(args) -> int:
+    try:
+        kb = _load_kb(args)
+    except KnowledgeBaseNotFound as e:
+        print(str(e), file=sys.stderr)
+        return 2
+    text = _load_input(args)
+    result = inspect_prompt(text, profile=args.profile, knowledge_base=kb)
+    for token in result.tokens:
+        path = " > ".join(token.category_path) if token.category_path else "-"
+        print(f"{token.text}\t{token.section.value}\t{path}")
+    if result.unknown_tags:
+        print("unknown:", ", ".join(result.unknown_tags), file=sys.stderr)
+        return 1
+    return 0
+
+
+def cmd_fix(args) -> int:
+    try:
+        kb = _load_kb(args)
+    except KnowledgeBaseNotFound as e:
+        print(str(e), file=sys.stderr)
+        return 2
+    text = _load_input(args)
+    result = correct_prompt(text, profile=args.profile, knowledge_base=kb)
+    if args.in_place:
+        if not args.file:
+            print("--in-place requires --file", file=sys.stderr)
+            return 2
+        Path(args.file).write_text(result.text, encoding="utf-8")
+    else:
+        print(result.text)
+    for warning in result.warnings:
+        print(warning, file=sys.stderr)
+    return 1 if result.unknown_tags and args.fail_on_unknown else 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    build = sub.add_parser("build-index", help="Build tag_index.jsonl from CSV")
+    build.add_argument("--tag-csv", required=True)
+    build.add_argument("--output", required=True)
+    build.set_defaults(func=cmd_build_index)
+
+    build_animadex = sub.add_parser(
+        "build-animadex-index",
+        help="Build character_index.jsonl and artist_index.jsonl from AnimaDex CSVs",
+    )
+    build_animadex.add_argument("--characters-csv", required=True)
+    build_animadex.add_argument("--artists-csv", required=True)
+    build_animadex.add_argument("--output-dir", required=True)
+    build_animadex.set_defaults(func=cmd_build_animadex_index)
+
+    save_token = sub.add_parser(
+        "animadex-save-token",
+        help="Save an animadex.net offline export token outside the repository",
+    )
+    save_token.add_argument("--token", default=None)
+    save_token.add_argument("--token-file", default=None)
+    save_token.add_argument("--site", default="https://animadex.net")
+    save_token.set_defaults(func=cmd_animadex_save_token)
+
+    import_cmd = sub.add_parser(
+        "animadex-import",
+        help="Download AnimaDex characters.csv and artists.csv with an export token",
+    )
+    import_cmd.add_argument("--token", default=None)
+    import_cmd.add_argument("--token-file", default=None)
+    import_cmd.add_argument("--site", default=None)
+    import_cmd.add_argument("--output-dir", default=str(ANIMADEX_DEFAULT_DATA_DIR))
+    import_cmd.add_argument("--full", action="store_true")
+    import_cmd.add_argument("--save-token", action="store_true")
+    import_cmd.add_argument("--build-index", action="store_true")
+    import_cmd.add_argument("--index-dir", default=None)
+    import_cmd.set_defaults(func=cmd_animadex_import)
+
+    for name, func in (("check", cmd_check), ("fix", cmd_fix)):
+        p = sub.add_parser(name)
+        _add_db_args(p)
+        p.add_argument("--profile", choices=("prompt", "caption"), default="prompt")
+        p.add_argument("--text", default=None)
+        p.add_argument("--file", default=None)
+        if name == "fix":
+            p.add_argument("--in-place", action="store_true")
+            p.add_argument("--fail-on-unknown", action="store_true")
+        p.set_defaults(func=func)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/library/anima_prompt/correction.py
+++ b/library/anima_prompt/correction.py
@@ -1,0 +1,120 @@
+"""Prompt inspection and correction."""
+
+from __future__ import annotations
+
+from .knowledge import PromptKnowledgeBase
+from .models import CorrectionResult, TagToken
+from .normalize import lookup_key, normalize_tag, render_artist_tag
+from .ordering import classify_tag, section_sort_key
+from .parser import parse_prompt, render_tags
+
+
+def _render_token(raw: str, section_name: str) -> str:
+    if section_name == "artist":
+        return render_artist_tag(raw)
+    normalized = normalize_tag(raw)
+    return normalized[1:] if normalized.startswith("@") else normalized
+
+
+def inspect_prompt(
+    text: str,
+    *,
+    profile: str = "prompt",
+    knowledge_base: PromptKnowledgeBase | None = None,
+) -> CorrectionResult:
+    """Parse and classify a prompt without reordering it."""
+
+    kb = knowledge_base or PromptKnowledgeBase.empty()
+    parsed = parse_prompt(text, profile=profile)
+    tokens: list[TagToken] = []
+    unknown: list[str] = []
+    seen: set[str] = set()
+    duplicates: list[str] = []
+
+    for raw in parsed.tokens:
+        normalized = normalize_tag(raw)
+        key = lookup_key(normalized)
+        info = kb.lookup(normalized)
+        section = classify_tag(normalized, info)
+        dedupe_key = key
+        if dedupe_key in seen:
+            duplicates.append(normalized)
+        else:
+            seen.add(dedupe_key)
+        if info is None:
+            unknown.append(normalized)
+        tokens.append(
+            TagToken(
+                raw=raw,
+                normalized=normalized,
+                lookup_key=key,
+                text=_render_token(normalized, section.value),
+                known=info is not None,
+                section=section,
+                category_path=info.category_path if info else (),
+                source=info.source if info else None,
+            )
+        )
+
+    return CorrectionResult(
+        text=text,
+        original_text=text,
+        tokens=tuple(tokens),
+        unknown_tags=tuple(unknown),
+        duplicate_tags=tuple(duplicates),
+        warnings=(),
+        changed=False,
+        report={
+            "profile": parsed.profile,
+            "delimiter": parsed.delimiter,
+            "sections": [token.section.value for token in tokens],
+        },
+    )
+
+
+def correct_prompt(
+    text: str,
+    *,
+    profile: str = "prompt",
+    knowledge_base: PromptKnowledgeBase | None = None,
+) -> CorrectionResult:
+    """Normalize, deduplicate, classify, and reorder a prompt for ANIMA."""
+
+    kb = knowledge_base or PromptKnowledgeBase.empty()
+    parsed = parse_prompt(text, profile=profile)
+    inspected = inspect_prompt(text, profile=profile, knowledge_base=kb)
+
+    kept: list[tuple[int, TagToken]] = []
+    seen: set[str] = set()
+    duplicates: list[str] = []
+    for index, token in enumerate(inspected.tokens):
+        if token.lookup_key in seen:
+            duplicates.append(token.normalized)
+            continue
+        seen.add(token.lookup_key)
+        kept.append((index, token))
+
+    kept.sort(key=lambda item: section_sort_key(item[0], item[1].section))
+    ordered = [token.text for _, token in kept]
+    corrected = render_tags(ordered, parsed.delimiter)
+    warnings: list[str] = []
+    if inspected.unknown_tags:
+        warnings.append(f"unknown tags: {', '.join(inspected.unknown_tags)}")
+    if duplicates:
+        warnings.append(f"duplicate tags removed: {', '.join(duplicates)}")
+
+    return CorrectionResult(
+        text=corrected,
+        original_text=text,
+        tokens=tuple(token for _, token in kept),
+        unknown_tags=inspected.unknown_tags,
+        duplicate_tags=tuple(duplicates),
+        warnings=tuple(warnings),
+        changed=corrected != text,
+        report={
+            "profile": parsed.profile,
+            "delimiter": parsed.delimiter,
+            "sections": [token.section.value for _, token in kept],
+            "removed_duplicates": duplicates,
+        },
+    )

--- a/library/anima_prompt/correction.py
+++ b/library/anima_prompt/correction.py
@@ -8,12 +8,54 @@ from .normalize import lookup_key, normalize_tag, render_artist_tag
 from .ordering import classify_tag, section_sort_key
 from .parser import parse_prompt, render_tags
 
+NO_ARTIST_TAG = "@no-artist"
+
 
 def _render_token(raw: str, section_name: str) -> str:
     if section_name == "artist":
         return render_artist_tag(raw)
-    normalized = normalize_tag(raw)
-    return normalized[1:] if normalized.startswith("@") else normalized
+    return normalize_tag(raw)
+
+
+def _tag_key_set(tags) -> set[str]:
+    return {lookup_key(str(tag)) for tag in tags or () if str(tag).strip()}
+
+
+def _classify_with_artist_options(
+    normalized: str,
+    *,
+    info,
+    kb: PromptKnowledgeBase,
+    validate_artist_tags: bool,
+    artist_overrides: set[str],
+    artist_exclusions: set[str],
+):
+    key = lookup_key(normalized)
+    is_no_artist = key == lookup_key(NO_ARTIST_TAG)
+    if key in artist_exclusions:
+        return classify_tag(normalized.lstrip("@"), None)
+    if key in artist_overrides or is_no_artist:
+        return classify_tag(f"@{key}", info)
+    if normalized.strip().startswith("@"):
+        if not validate_artist_tags:
+            return classify_tag(normalized, info)
+        if key in kb.animadex.artists:
+            return classify_tag(normalized, info)
+        return classify_tag(normalized.lstrip("@"), None)
+    return classify_tag(normalized, info)
+
+
+def _no_artist_token() -> TagToken:
+    key = lookup_key(NO_ARTIST_TAG)
+    return TagToken(
+        raw=NO_ARTIST_TAG,
+        normalized=NO_ARTIST_TAG,
+        lookup_key=key,
+        text=NO_ARTIST_TAG,
+        known=True,
+        section=classify_tag(NO_ARTIST_TAG),
+        source="manual",
+    )
 
 
 def inspect_prompt(
@@ -21,10 +63,15 @@ def inspect_prompt(
     *,
     profile: str = "prompt",
     knowledge_base: PromptKnowledgeBase | None = None,
+    validate_artist_tags: bool = False,
+    artist_overrides=(),
+    artist_exclusions=(),
 ) -> CorrectionResult:
     """Parse and classify a prompt without reordering it."""
 
     kb = knowledge_base or PromptKnowledgeBase.empty()
+    override_keys = _tag_key_set(artist_overrides)
+    exclusion_keys = _tag_key_set(artist_exclusions)
     parsed = parse_prompt(text, profile=profile)
     tokens: list[TagToken] = []
     unknown: list[str] = []
@@ -35,7 +82,14 @@ def inspect_prompt(
         normalized = normalize_tag(raw)
         key = lookup_key(normalized)
         info = kb.lookup(normalized)
-        section = classify_tag(normalized, info)
+        section = _classify_with_artist_options(
+            normalized,
+            info=info,
+            kb=kb,
+            validate_artist_tags=validate_artist_tags,
+            artist_overrides=override_keys,
+            artist_exclusions=exclusion_keys,
+        )
         dedupe_key = key
         if dedupe_key in seen:
             duplicates.append(normalized)
@@ -77,12 +131,23 @@ def correct_prompt(
     *,
     profile: str = "prompt",
     knowledge_base: PromptKnowledgeBase | None = None,
+    validate_artist_tags: bool = False,
+    insert_no_artist: bool = False,
+    artist_overrides=(),
+    artist_exclusions=(),
 ) -> CorrectionResult:
     """Normalize, deduplicate, classify, and reorder a prompt for ANIMA."""
 
     kb = knowledge_base or PromptKnowledgeBase.empty()
     parsed = parse_prompt(text, profile=profile)
-    inspected = inspect_prompt(text, profile=profile, knowledge_base=kb)
+    inspected = inspect_prompt(
+        text,
+        profile=profile,
+        knowledge_base=kb,
+        validate_artist_tags=validate_artist_tags,
+        artist_overrides=artist_overrides,
+        artist_exclusions=artist_exclusions,
+    )
 
     kept: list[tuple[int, TagToken]] = []
     seen: set[str] = set()
@@ -93,6 +158,13 @@ def correct_prompt(
             continue
         seen.add(token.lookup_key)
         kept.append((index, token))
+
+    if insert_no_artist and not any(
+        token.section.value == "artist" for _, token in kept
+    ):
+        no_artist = _no_artist_token()
+        if no_artist.lookup_key not in seen:
+            kept.append((len(inspected.tokens), no_artist))
 
     kept.sort(key=lambda item: section_sort_key(item[0], item[1].section))
     ordered = [token.text for _, token in kept]

--- a/library/anima_prompt/correction.py
+++ b/library/anima_prompt/correction.py
@@ -32,9 +32,11 @@ def _classify_with_artist_options(
 ):
     key = lookup_key(normalized)
     is_no_artist = key == lookup_key(NO_ARTIST_TAG)
+    if is_no_artist:
+        return classify_tag(NO_ARTIST_TAG, info)
     if key in artist_exclusions:
         return classify_tag(normalized.lstrip("@"), None)
-    if key in artist_overrides or is_no_artist:
+    if key in artist_overrides:
         return classify_tag(f"@{key}", info)
     if normalized.strip().startswith("@"):
         if not validate_artist_tags:
@@ -82,6 +84,7 @@ def inspect_prompt(
         normalized = normalize_tag(raw)
         key = lookup_key(normalized)
         info = kb.lookup(normalized)
+        manual_known = key == lookup_key(NO_ARTIST_TAG) or key in override_keys
         section = _classify_with_artist_options(
             normalized,
             info=info,
@@ -95,7 +98,7 @@ def inspect_prompt(
             duplicates.append(normalized)
         else:
             seen.add(dedupe_key)
-        if info is None:
+        if info is None and not manual_known:
             unknown.append(normalized)
         tokens.append(
             TagToken(
@@ -103,7 +106,7 @@ def inspect_prompt(
                 normalized=normalized,
                 lookup_key=key,
                 text=_render_token(normalized, section.value),
-                known=info is not None,
+                known=info is not None or manual_known,
                 section=section,
                 category_path=info.category_path if info else (),
                 source=info.source if info else None,

--- a/library/anima_prompt/knowledge.py
+++ b/library/anima_prompt/knowledge.py
@@ -183,6 +183,19 @@ def _candidate_paths(
     return paths
 
 
+def _explicit_or_env_paths(
+    explicit: str | os.PathLike | None,
+    env_name: str,
+) -> list[Path]:
+    paths: list[Path] = []
+    if explicit:
+        paths.append(Path(explicit))
+    env = os.environ.get(env_name)
+    if env:
+        paths.append(Path(env))
+    return paths
+
+
 def _first_file(paths: Iterable[Path]) -> Path | None:
     seen: set[Path] = set()
     for path in paths:
@@ -206,27 +219,20 @@ def load_knowledge_base(
 ) -> PromptKnowledgeBase:
     """Load local prompt knowledge from CSV/JSONL sources.
 
-    Resolution priority is explicit argument, environment variable, then a
-    workspace-local default filename. Missing data raises a clear error unless
-    ``allow_missing`` is set.
+    General Danbooru tag data is loaded only when explicitly configured by
+    argument or environment variable. AnimaDex data is auto-discovered from the
+    workspace-local models/animadex paths.
     """
 
-    index_path = _first_file(
-        _candidate_paths(tag_index, TAG_INDEX_ENV, DEFAULT_TAG_INDEX_NAME)
-    )
-    csv_path = _first_file(_candidate_paths(tag_csv, TAG_CSV_ENV, DEFAULT_TAG_CSV_NAME))
+    index_path = _first_file(_explicit_or_env_paths(tag_index, TAG_INDEX_ENV))
+    csv_path = _first_file(_explicit_or_env_paths(tag_csv, TAG_CSV_ENV))
 
     if index_path:
         general = GeneralTagDB.from_jsonl(index_path)
     elif csv_path:
         general = GeneralTagDB.from_csv(csv_path)
-    elif allow_missing:
-        general = GeneralTagDB()
     else:
-        raise KnowledgeBaseNotFound(
-            "No tag DB found. Pass --tag-csv/--tag-index or set "
-            f"{TAG_CSV_ENV}/{TAG_INDEX_ENV}."
-        )
+        general = GeneralTagDB()
 
     character_index_path = _first_file(
         _candidate_paths(
@@ -269,5 +275,17 @@ def load_knowledge_base(
         animadex = AnimaDexDB.from_csvs(
             characters_csv=char_csv_path,
             artists_csv=artist_csv_path,
+        )
+    if (
+        not allow_missing
+        and not general.tags
+        and not animadex.characters
+        and not animadex.copyrights
+        and not animadex.artists
+        and not animadex.core_tags
+    ):
+        raise KnowledgeBaseNotFound(
+            "No prompt DB found. Import AnimaDex CSVs under models/animadex or "
+            "pass explicit tag/AnimaDex paths."
         )
     return PromptKnowledgeBase(general=general, animadex=animadex)

--- a/library/anima_prompt/knowledge.py
+++ b/library/anima_prompt/knowledge.py
@@ -10,9 +10,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable
 
-from .animadex import AnimaDexDB, GENDER_TAGS
+from .animadex import AnimaDexDB
 from .models import TagInfo
 from .normalize import lookup_key
+from .ordering import ANIMA_PERSON_COUNT_TAGS
 
 TAG_CSV_ENV = "ANIMA_PROMPT_TAG_CSV"
 TAG_INDEX_ENV = "ANIMA_PROMPT_TAG_INDEX"
@@ -151,11 +152,10 @@ class PromptKnowledgeBase:
                 post_count=info.post_count if info else None,
                 source="animadex",
             )
-        if key in self.animadex.core_tags:
-            category_path = ("인물", "인원수") if key in GENDER_TAGS else ("일반",)
+        if key in self.animadex.core_tags and key in ANIMA_PERSON_COUNT_TAGS:
             return TagInfo(
                 tag=key,
-                category_path=category_path,
+                category_path=("인물", "인원수"),
                 post_count=info.post_count if info else None,
                 source="animadex_core",
             )

--- a/library/anima_prompt/knowledge.py
+++ b/library/anima_prompt/knowledge.py
@@ -1,0 +1,273 @@
+"""Local tag database loading for ANIMA prompt correction."""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+from .animadex import AnimaDexDB, GENDER_TAGS
+from .models import TagInfo
+from .normalize import lookup_key
+
+TAG_CSV_ENV = "ANIMA_PROMPT_TAG_CSV"
+TAG_INDEX_ENV = "ANIMA_PROMPT_TAG_INDEX"
+ANIMADEX_CHARACTERS_ENV = "ANIMADEX_CHARACTERS_CSV"
+ANIMADEX_ARTISTS_ENV = "ANIMADEX_ARTISTS_CSV"
+ANIMADEX_CHARACTER_INDEX_ENV = "ANIMADEX_CHARACTER_INDEX"
+ANIMADEX_ARTIST_INDEX_ENV = "ANIMADEX_ARTIST_INDEX"
+
+DEFAULT_TAG_CSV_NAME = "KR_danbooru_tags_with_description v3_modified.csv"
+DEFAULT_TAG_INDEX_NAME = "tag_index.jsonl"
+DEFAULT_CHARACTER_INDEX_NAME = "character_index.jsonl"
+DEFAULT_ARTIST_INDEX_NAME = "artist_index.jsonl"
+DEFAULT_ANIMADEX_IMPORT_DIR = Path("data") / "animadex" / "import"
+DEFAULT_ANIMADEX_INDEX_DIR = Path("data") / "animadex" / "index"
+
+_CATEGORY_RE = re.compile(r"^\s*\[([^\]]+)\]")
+
+
+class KnowledgeBaseNotFound(FileNotFoundError):
+    """Raised when no local tag data source could be resolved."""
+
+
+def parse_category_path(description: str) -> tuple[str, ...]:
+    match = _CATEGORY_RE.match(description or "")
+    if not match:
+        return ()
+    return tuple(part.strip() for part in match.group(1).split(">") if part.strip())
+
+
+def _parse_int(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(str(value).replace(",", "").strip())
+    except ValueError:
+        return None
+
+
+@dataclass
+class GeneralTagDB:
+    tags: dict[str, TagInfo] = field(default_factory=dict)
+
+    @classmethod
+    def from_csv(cls, path: str | os.PathLike) -> "GeneralTagDB":
+        tags: dict[str, TagInfo] = {}
+        with Path(path).open("r", encoding="utf-8-sig", newline="") as f:
+            reader = csv.reader(f)
+            for row in reader:
+                if not row or len(row) < 1:
+                    continue
+                raw_tag = row[0].strip()
+                if not raw_tag or raw_tag.lower() == "tag":
+                    continue
+                count = _parse_int(row[2] if len(row) > 2 else None)
+                desc = row[3] if len(row) > 3 else ""
+                key = lookup_key(raw_tag)
+                tags[key] = TagInfo(
+                    tag=key,
+                    category_path=parse_category_path(desc),
+                    post_count=count,
+                    source="general",
+                )
+        return cls(tags)
+
+    @classmethod
+    def from_jsonl(cls, path: str | os.PathLike) -> "GeneralTagDB":
+        tags: dict[str, TagInfo] = {}
+        with Path(path).open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                data = json.loads(line)
+                key = lookup_key(str(data.get("tag") or ""))
+                if not key:
+                    continue
+                tags[key] = TagInfo(
+                    tag=key,
+                    category_path=tuple(data.get("category_path") or ()),
+                    post_count=data.get("post_count"),
+                    source=str(data.get("source") or "general"),
+                )
+        return cls(tags)
+
+    def write_jsonl(self, path: str | os.PathLike) -> None:
+        out = Path(path)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        with out.open("w", encoding="utf-8", newline="\n") as f:
+            for key in sorted(self.tags):
+                info = self.tags[key]
+                f.write(
+                    json.dumps(
+                        {
+                            "tag": info.tag,
+                            "category_path": list(info.category_path),
+                            "post_count": info.post_count,
+                            "source": info.source,
+                        },
+                        ensure_ascii=False,
+                        sort_keys=True,
+                    )
+                    + "\n"
+                )
+
+
+@dataclass
+class PromptKnowledgeBase:
+    general: GeneralTagDB = field(default_factory=GeneralTagDB)
+    animadex: AnimaDexDB = field(default_factory=AnimaDexDB)
+
+    @classmethod
+    def empty(cls) -> "PromptKnowledgeBase":
+        return cls()
+
+    def lookup(self, tag: str) -> TagInfo | None:
+        key = lookup_key(tag)
+        info = self.general.tags.get(key)
+        if key in self.animadex.characters:
+            return TagInfo(
+                tag=key,
+                category_path=("캐릭터",),
+                post_count=info.post_count if info else None,
+                source="animadex",
+            )
+        if key in self.animadex.copyrights:
+            return TagInfo(
+                tag=key,
+                category_path=("작품",),
+                post_count=info.post_count if info else None,
+                source="animadex",
+            )
+        if key in self.animadex.artists:
+            return TagInfo(
+                tag=key,
+                category_path=("작가",),
+                post_count=info.post_count if info else None,
+                source="animadex",
+            )
+        if key in self.animadex.core_tags:
+            category_path = ("인물", "인원수") if key in GENDER_TAGS else ("일반",)
+            return TagInfo(
+                tag=key,
+                category_path=category_path,
+                post_count=info.post_count if info else None,
+                source="animadex_core",
+            )
+        return info
+
+
+def _candidate_paths(
+    explicit: str | os.PathLike | None,
+    env_name: str,
+    default_name: str | os.PathLike,
+    *,
+    extra_defaults: Iterable[str | os.PathLike] = (),
+) -> list[Path]:
+    paths: list[Path] = []
+    if explicit:
+        paths.append(Path(explicit))
+    env = os.environ.get(env_name)
+    if env:
+        paths.append(Path(env))
+    cwd = Path.cwd()
+    for base in (cwd, *cwd.parents):
+        paths.append(base / default_name)
+        for default in extra_defaults:
+            paths.append(base / default)
+    return paths
+
+
+def _first_file(paths: Iterable[Path]) -> Path | None:
+    seen: set[Path] = set()
+    for path in paths:
+        if path in seen:
+            continue
+        seen.add(path)
+        if path.is_file():
+            return path
+    return None
+
+
+def load_knowledge_base(
+    *,
+    tag_csv: str | os.PathLike | None = None,
+    tag_index: str | os.PathLike | None = None,
+    animadex_characters_csv: str | os.PathLike | None = None,
+    animadex_artists_csv: str | os.PathLike | None = None,
+    animadex_character_index: str | os.PathLike | None = None,
+    animadex_artist_index: str | os.PathLike | None = None,
+    allow_missing: bool = False,
+) -> PromptKnowledgeBase:
+    """Load local prompt knowledge from CSV/JSONL sources.
+
+    Resolution priority is explicit argument, environment variable, then a
+    workspace-local default filename. Missing data raises a clear error unless
+    ``allow_missing`` is set.
+    """
+
+    index_path = _first_file(
+        _candidate_paths(tag_index, TAG_INDEX_ENV, DEFAULT_TAG_INDEX_NAME)
+    )
+    csv_path = _first_file(_candidate_paths(tag_csv, TAG_CSV_ENV, DEFAULT_TAG_CSV_NAME))
+
+    if index_path:
+        general = GeneralTagDB.from_jsonl(index_path)
+    elif csv_path:
+        general = GeneralTagDB.from_csv(csv_path)
+    elif allow_missing:
+        general = GeneralTagDB()
+    else:
+        raise KnowledgeBaseNotFound(
+            "No tag DB found. Pass --tag-csv/--tag-index or set "
+            f"{TAG_CSV_ENV}/{TAG_INDEX_ENV}."
+        )
+
+    character_index_path = _first_file(
+        _candidate_paths(
+            animadex_character_index,
+            ANIMADEX_CHARACTER_INDEX_ENV,
+            DEFAULT_CHARACTER_INDEX_NAME,
+            extra_defaults=(DEFAULT_ANIMADEX_INDEX_DIR / DEFAULT_CHARACTER_INDEX_NAME,),
+        )
+    )
+    artist_index_path = _first_file(
+        _candidate_paths(
+            animadex_artist_index,
+            ANIMADEX_ARTIST_INDEX_ENV,
+            DEFAULT_ARTIST_INDEX_NAME,
+            extra_defaults=(DEFAULT_ANIMADEX_INDEX_DIR / DEFAULT_ARTIST_INDEX_NAME,),
+        )
+    )
+    char_csv_path = _first_file(
+        _candidate_paths(
+            animadex_characters_csv,
+            ANIMADEX_CHARACTERS_ENV,
+            "characters.csv",
+            extra_defaults=(DEFAULT_ANIMADEX_IMPORT_DIR / "characters.csv",),
+        )
+    )
+    artist_csv_path = _first_file(
+        _candidate_paths(
+            animadex_artists_csv,
+            ANIMADEX_ARTISTS_ENV,
+            "artists.csv",
+            extra_defaults=(DEFAULT_ANIMADEX_IMPORT_DIR / "artists.csv",),
+        )
+    )
+    if character_index_path or artist_index_path:
+        animadex = AnimaDexDB.from_jsonl(
+            character_index=character_index_path,
+            artist_index=artist_index_path,
+        )
+    else:
+        animadex = AnimaDexDB.from_csvs(
+            characters_csv=char_csv_path,
+            artists_csv=artist_csv_path,
+        )
+    return PromptKnowledgeBase(general=general, animadex=animadex)

--- a/library/anima_prompt/knowledge.py
+++ b/library/anima_prompt/knowledge.py
@@ -25,8 +25,8 @@ DEFAULT_TAG_CSV_NAME = "KR_danbooru_tags_with_description v3_modified.csv"
 DEFAULT_TAG_INDEX_NAME = "tag_index.jsonl"
 DEFAULT_CHARACTER_INDEX_NAME = "character_index.jsonl"
 DEFAULT_ARTIST_INDEX_NAME = "artist_index.jsonl"
-DEFAULT_ANIMADEX_IMPORT_DIR = Path("data") / "animadex" / "import"
-DEFAULT_ANIMADEX_INDEX_DIR = Path("data") / "animadex" / "index"
+DEFAULT_ANIMADEX_IMPORT_DIR = Path("models") / "animadex" / "import"
+DEFAULT_ANIMADEX_INDEX_DIR = Path("models") / "animadex" / "index"
 
 _CATEGORY_RE = re.compile(r"^\s*\[([^\]]+)\]")
 

--- a/library/anima_prompt/models.py
+++ b/library/anima_prompt/models.py
@@ -1,0 +1,59 @@
+"""Small data models for prompt correction."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+
+class TagSection(StrEnum):
+    QUALITY = "quality"
+    META = "meta"
+    YEAR = "year"
+    SAFETY = "safety"
+    COUNT = "count"
+    CHARACTER = "character"
+    COPYRIGHT = "copyright"
+    ARTIST = "artist"
+    GENERAL = "general"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class TagInfo:
+    tag: str
+    category_path: tuple[str, ...] = ()
+    post_count: int | None = None
+    source: str = "general"
+
+
+@dataclass(frozen=True)
+class TagToken:
+    raw: str
+    normalized: str
+    lookup_key: str
+    text: str
+    known: bool = False
+    section: TagSection = TagSection.UNKNOWN
+    category_path: tuple[str, ...] = ()
+    source: str | None = None
+
+
+@dataclass(frozen=True)
+class ParsedPrompt:
+    text: str
+    tokens: tuple[str, ...]
+    delimiter: str
+    profile: str
+
+
+@dataclass(frozen=True)
+class CorrectionResult:
+    text: str
+    original_text: str
+    tokens: tuple[TagToken, ...]
+    unknown_tags: tuple[str, ...] = ()
+    duplicate_tags: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
+    changed: bool = False
+    report: dict[str, object] = field(default_factory=dict)

--- a/library/anima_prompt/normalize.py
+++ b/library/anima_prompt/normalize.py
@@ -1,0 +1,36 @@
+"""Tag normalization utilities for Danbooru-style prompts."""
+
+from __future__ import annotations
+
+import re
+
+_SPACE_RE = re.compile(r"\s+")
+
+
+def normalize_tag(tag: str) -> str:
+    """Normalize a tag for lookup and duplicate detection.
+
+    Danbooru tags are case-insensitive in practice and frequently appear with
+    either underscores or spaces. A leading ``@`` is kept because ANIMA uses it
+    to mark artist tags.
+    """
+
+    text = tag.strip().replace("_", " ").lower()
+    text = _SPACE_RE.sub(" ", text)
+    if text.startswith("@"):
+        text = "@" + text[1:].strip()
+    return text
+
+
+def lookup_key(tag: str) -> str:
+    """Return the canonical DB lookup key, without ANIMA's artist marker."""
+
+    normalized = normalize_tag(tag)
+    return normalized[1:].strip() if normalized.startswith("@") else normalized
+
+
+def render_artist_tag(tag: str) -> str:
+    """Render an ANIMA artist tag with ``@`` and underscore-separated name."""
+
+    key = lookup_key(tag)
+    return "@" + key.replace(" ", "_")

--- a/library/anima_prompt/ordering.py
+++ b/library/anima_prompt/ordering.py
@@ -1,0 +1,83 @@
+"""ANIMA tag classification and ordering rules."""
+
+from __future__ import annotations
+
+import re
+
+from .models import TagInfo, TagSection
+from .normalize import lookup_key
+
+QUALITY_TAGS = {
+    "masterpiece",
+    "best quality",
+    "high quality",
+    "absurdres",
+}
+META_TAGS = {
+    "highres",
+    "official art",
+    "scan",
+}
+YEAR_TAGS = {
+    "oldest",
+    "old",
+    "recent",
+    "newest",
+}
+SAFETY_TAGS = {
+    "safe",
+    "sensitive",
+    "questionable",
+    "explicit",
+}
+
+PERSON_TYPE_TAGS = {
+    "no humans",
+}
+
+COUNT_RE = re.compile(r"^\d+\s*(girl|girls|boy|boys|other|others)$")
+
+SECTION_ORDER = {
+    TagSection.QUALITY: 0,
+    TagSection.META: 1,
+    TagSection.YEAR: 2,
+    TagSection.SAFETY: 3,
+    TagSection.COUNT: 4,
+    TagSection.CHARACTER: 5,
+    TagSection.COPYRIGHT: 6,
+    TagSection.ARTIST: 7,
+    TagSection.GENERAL: 8,
+    TagSection.UNKNOWN: 9,
+}
+
+
+def classify_tag(tag: str, info: TagInfo | None = None) -> TagSection:
+    key = lookup_key(tag)
+    if key in QUALITY_TAGS:
+        return TagSection.QUALITY
+    if key in META_TAGS:
+        return TagSection.META
+    if key in YEAR_TAGS:
+        return TagSection.YEAR
+    if key in SAFETY_TAGS:
+        return TagSection.SAFETY
+    if COUNT_RE.match(key) or key in PERSON_TYPE_TAGS:
+        return TagSection.COUNT
+    if tag.strip().startswith("@"):
+        return TagSection.ARTIST
+
+    category_path = info.category_path if info else ()
+    root = category_path[0] if category_path else ""
+    if root == "캐릭터":
+        return TagSection.CHARACTER
+    if root in {"작품", "미디어"}:
+        return TagSection.COPYRIGHT
+    if root == "작가":
+        return TagSection.ARTIST
+    if root == "인물" and any(part == "인원수" for part in category_path):
+        return TagSection.COUNT
+    return TagSection.GENERAL if info is not None else TagSection.UNKNOWN
+
+
+def section_sort_key(index: int, section: TagSection) -> tuple[int, int]:
+    return (SECTION_ORDER.get(section, SECTION_ORDER[TagSection.UNKNOWN]), index)

--- a/library/anima_prompt/ordering.py
+++ b/library/anima_prompt/ordering.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import re
-
 from .models import TagInfo, TagSection
 from .normalize import lookup_key
 
@@ -31,11 +29,33 @@ SAFETY_TAGS = {
     "explicit",
 }
 
-PERSON_TYPE_TAGS = {
-    "no humans",
-}
-
-COUNT_RE = re.compile(r"^\d+\s*(girl|girls|boy|boys|other|others)$")
+ANIMA_PERSON_COUNT_TAGS = frozenset(
+    {
+        "solo",
+        "no humans",
+        "multiple boys",
+        "multiple girls",
+        "multiple others",
+        "1boy",
+        "2boys",
+        "3boys",
+        "4boys",
+        "5boys",
+        "6+boys",
+        "1girl",
+        "2girls",
+        "3girls",
+        "4girls",
+        "5girls",
+        "6+girls",
+        "1other",
+        "2others",
+        "3others",
+        "4others",
+        "5others",
+        "6+others",
+    }
+)
 
 SECTION_ORDER = {
     TagSection.QUALITY: 0,
@@ -47,7 +67,7 @@ SECTION_ORDER = {
     TagSection.COPYRIGHT: 6,
     TagSection.ARTIST: 7,
     TagSection.GENERAL: 8,
-    TagSection.UNKNOWN: 9,
+    TagSection.UNKNOWN: 8,
 }
 
 
@@ -61,7 +81,7 @@ def classify_tag(tag: str, info: TagInfo | None = None) -> TagSection:
         return TagSection.YEAR
     if key in SAFETY_TAGS:
         return TagSection.SAFETY
-    if COUNT_RE.match(key) or key in PERSON_TYPE_TAGS:
+    if key in ANIMA_PERSON_COUNT_TAGS:
         return TagSection.COUNT
     if tag.strip().startswith("@"):
         return TagSection.ARTIST

--- a/library/anima_prompt/parser.py
+++ b/library/anima_prompt/parser.py
@@ -1,0 +1,37 @@
+"""Danbooru-style prompt and caption parsing."""
+
+from __future__ import annotations
+
+from .models import ParsedPrompt
+
+
+def parse_prompt(text: str, *, profile: str = "prompt") -> ParsedPrompt:
+    """Parse prompt text into raw tag tokens.
+
+    ``prompt`` profile prefers comma-separated tags. ``caption`` profile keeps
+    newline-separated captions as newline-separated output. For convenience,
+    caption text that has no newline but has commas is parsed as comma-separated
+    input; this lets CLI checks inspect existing prompt snippets without
+    converting line-based caption files to comma style.
+    """
+
+    profile = (profile or "prompt").strip().lower()
+    if profile == "caption" and "\n" in text:
+        delimiter = "\n"
+        tokens = [part.strip() for part in text.splitlines()]
+    else:
+        delimiter = ", "
+        tokens = [part.strip() for part in text.split(",")]
+    tokens = [part for part in tokens if part]
+    return ParsedPrompt(
+        text=text,
+        tokens=tuple(tokens),
+        delimiter=delimiter,
+        profile=profile,
+    )
+
+
+def render_tags(tags: list[str], delimiter: str) -> str:
+    if delimiter == "\n":
+        return "\n".join(tags)
+    return ", ".join(tags)

--- a/scripts/anima_prompt.py
+++ b/scripts/anima_prompt.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""Thin wrapper for ``python -m library.anima_prompt.cli``."""
+
+from library.anima_prompt.cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_anima_prompt.py
+++ b/tests/test_anima_prompt.py
@@ -85,6 +85,32 @@ def test_artist_validation_keeps_unknown_trigger_out_of_artist_slot() -> None:
     assert result.text == "1girl, gotoh hitori, @no-artist, long hair, @special trigger"
 
 
+def test_no_artist_placeholder_sorts_in_artist_slot_with_or_without_marker() -> None:
+    db = AnimaDexDB()
+    db.characters.add("hatsune miku")
+    db.copyrights.add("vocaloid")
+    db.core_tags.add("1girl")
+    kb = PromptKnowledgeBase(animadex=db)
+
+    for placeholder in ("no-artist", "@no-artist"):
+        result = correct_prompt(
+            f"long hair, vocaloid, {placeholder}, hatsune miku, 1girl",
+            knowledge_base=kb,
+            validate_artist_tags=True,
+            insert_no_artist=True,
+        )
+
+        assert result.text == "1girl, hatsune miku, vocaloid, @no-artist, long hair"
+        assert result.unknown_tags == ("long hair",)
+        assert [token.section.value for token in result.tokens] == [
+            "count",
+            "character",
+            "copyright",
+            "artist",
+            "unknown",
+        ]
+
+
 def test_artist_override_can_promote_manual_trigger_word() -> None:
     result = correct_prompt(
         "long hair, @special_trigger, 1girl",

--- a/tests/test_anima_prompt.py
+++ b/tests/test_anima_prompt.py
@@ -11,6 +11,7 @@ from library.anima_prompt import (
     PromptKnowledgeBase,
     correct_prompt,
     inspect_prompt,
+    load_knowledge_base,
 )
 from library.anima_prompt.animadex import ANIMADEX_DEFAULT_DATA_DIR
 from library.anima_prompt.knowledge import parse_category_path
@@ -73,6 +74,63 @@ def test_unknown_and_duplicates_reported() -> None:
     assert result.duplicate_tags == ("1girl",)
 
 
+def test_artist_validation_keeps_unknown_trigger_out_of_artist_slot() -> None:
+    result = correct_prompt(
+        "long hair, @special_trigger, gotoh hitori, 1girl",
+        knowledge_base=_kb(),
+        validate_artist_tags=True,
+        insert_no_artist=True,
+    )
+
+    assert result.text == "1girl, gotoh hitori, @no-artist, long hair, @special trigger"
+
+
+def test_artist_override_can_promote_manual_trigger_word() -> None:
+    result = correct_prompt(
+        "long hair, @special_trigger, 1girl",
+        knowledge_base=_kb(),
+        validate_artist_tags=True,
+        insert_no_artist=True,
+        artist_overrides=["special trigger"],
+    )
+
+    assert result.text == "1girl, @special_trigger, long hair"
+
+
+def test_artist_exclusion_forces_known_artist_out_of_artist_slot() -> None:
+    result = correct_prompt(
+        "long hair, @artist_name, 1girl",
+        knowledge_base=_kb(),
+        validate_artist_tags=True,
+        insert_no_artist=True,
+        artist_exclusions=["artist name"],
+    )
+
+    assert result.text == "1girl, @no-artist, long hair, @artist name"
+
+
+def test_artist_validation_uses_animadex_artist_db_not_general_tag_db() -> None:
+    result = correct_prompt(
+        "long hair, @artist_name, 1girl",
+        knowledge_base=_kb(),
+        validate_artist_tags=True,
+        insert_no_artist=True,
+    )
+
+    assert result.text == "1girl, @no-artist, long hair, @artist name"
+
+    db = AnimaDexDB()
+    db.artists.add("artist name")
+    animadex_result = correct_prompt(
+        "long hair, @artist_name, 1girl",
+        knowledge_base=PromptKnowledgeBase(general=_kb().general, animadex=db),
+        validate_artist_tags=True,
+        insert_no_artist=True,
+    )
+
+    assert animadex_result.text == "1girl, @artist_name, long hair"
+
+
 def test_general_tag_db_from_csv_and_jsonl(tmp_path: Path) -> None:
     csv_path = tmp_path / "tags.csv"
     csv_path.write_text(
@@ -87,6 +145,19 @@ def test_general_tag_db_from_csv_and_jsonl(tmp_path: Path) -> None:
     db.write_jsonl(jsonl)
     loaded = GeneralTagDB.from_jsonl(jsonl)
     assert loaded.tags["gotoh hitori"].category_path == ("캐릭터",)
+
+
+def test_load_knowledge_base_does_not_auto_load_workspace_general_csv(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    csv_path = tmp_path / "KR_danbooru_tags_with_description v3_modified.csv"
+    csv_path.write_text('artist name,0,5,"[작가] artist"\n', encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    kb = load_knowledge_base(allow_missing=True)
+
+    assert "artist name" not in kb.general.tags
 
 
 def test_inspect_prompt_keeps_original_order() -> None:

--- a/tests/test_anima_prompt.py
+++ b/tests/test_anima_prompt.py
@@ -111,6 +111,37 @@ def test_no_artist_placeholder_sorts_in_artist_slot_with_or_without_marker() -> 
         ]
 
 
+def test_anima_person_count_tags_are_builtin() -> None:
+    result = correct_prompt(
+        "long hair, hatsune miku, multiple girls, 6+girls, solo",
+        knowledge_base=PromptKnowledgeBase.empty(),
+    )
+
+    assert result.text == "multiple girls, 6+girls, solo, long hair, hatsune miku"
+    assert [token.section.value for token in result.tokens] == [
+        "count",
+        "count",
+        "count",
+        "unknown",
+        "unknown",
+    ]
+
+
+def test_general_and_unknown_tail_preserves_input_order() -> None:
+    result = correct_prompt(
+        "mystery tag, long hair, 1girl, another unknown",
+        knowledge_base=_kb(),
+    )
+
+    assert result.text == "1girl, mystery tag, long hair, another unknown"
+    assert [token.section.value for token in result.tokens] == [
+        "count",
+        "unknown",
+        "general",
+        "unknown",
+    ]
+
+
 def test_artist_override_can_promote_manual_trigger_word() -> None:
     result = correct_prompt(
         "long hair, @special_trigger, 1girl",
@@ -193,7 +224,7 @@ def test_inspect_prompt_keeps_original_order() -> None:
     assert [token.section.value for token in result.tokens] == ["general", "count"]
 
 
-def test_animadex_csv_classifies_character_copyright_artist_and_core_tags(
+def test_animadex_csv_classifies_character_copyright_artist_and_count_core_tags(
     tmp_path: Path,
 ) -> None:
     characters = tmp_path / "characters.csv"
@@ -219,13 +250,13 @@ def test_animadex_csv_classifies_character_copyright_artist_and_core_tags(
     )
 
     assert result.text == "1girl, hatsune miku, vocaloid, @0-den, twintails"
-    assert result.unknown_tags == ()
+    assert result.unknown_tags == ("twintails",)
     assert [token.section.value for token in result.tokens] == [
         "count",
         "character",
         "copyright",
         "artist",
-        "general",
+        "unknown",
     ]
 
 

--- a/tests/test_anima_prompt.py
+++ b/tests/test_anima_prompt.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from library.anima_prompt import (
+    AnimaDexDB,
+    AnimaDexImportClient,
+    AnimaDexImportToken,
+    AnimaDexTokenStore,
+    GeneralTagDB,
+    PromptKnowledgeBase,
+    correct_prompt,
+    inspect_prompt,
+)
+from library.anima_prompt.knowledge import parse_category_path
+
+
+def _kb() -> PromptKnowledgeBase:
+    tags = {
+        "1girl": ("캐릭터", "인원수"),
+        "gotoh hitori": ("캐릭터",),
+        "bocchi the rock!": ("작품",),
+        "artist name": ("작가",),
+        "long hair": ("패션", "헤어스타일"),
+    }
+    db = GeneralTagDB()
+    from library.anima_prompt.models import TagInfo
+
+    db.tags = {
+        tag: TagInfo(tag=tag, category_path=path, source="test")
+        for tag, path in tags.items()
+    }
+    return PromptKnowledgeBase(general=db)
+
+
+def test_parse_description_category_path() -> None:
+    assert parse_category_path("[캐릭터 > 작품] desc") == ("캐릭터", "작품")
+    assert parse_category_path("desc only") == ()
+
+
+def test_correct_prompt_orders_anima_sections() -> None:
+    result = correct_prompt(
+        "long_hair, @artist_name, bocchi the rock!, gotoh hitori, 1girl",
+        knowledge_base=_kb(),
+    )
+
+    assert result.text == (
+        "1girl, gotoh hitori, bocchi the rock!, @artist_name, long hair"
+    )
+    assert result.changed is True
+
+
+def test_caption_profile_preserves_newline_delimiter() -> None:
+    result = correct_prompt(
+        "long hair\nartist name\n1girl",
+        profile="caption",
+        knowledge_base=_kb(),
+    )
+
+    assert result.text == "1girl\n@artist_name\nlong hair"
+
+
+def test_unknown_and_duplicates_reported() -> None:
+    result = correct_prompt("1girl, mystery tag, 1girl", knowledge_base=_kb())
+
+    assert result.text == "1girl, mystery tag"
+    assert result.unknown_tags == ("mystery tag",)
+    assert result.duplicate_tags == ("1girl",)
+
+
+def test_general_tag_db_from_csv_and_jsonl(tmp_path: Path) -> None:
+    csv_path = tmp_path / "tags.csv"
+    csv_path.write_text(
+        '1girl,0,10,"[인물 > 인원수] one girl"\n'
+        'gotoh hitori,0,5,"[캐릭터] character"\n',
+        encoding="utf-8",
+    )
+    db = GeneralTagDB.from_csv(csv_path)
+    assert db.tags["1girl"].category_path == ("인물", "인원수")
+
+    jsonl = tmp_path / "tag_index.jsonl"
+    db.write_jsonl(jsonl)
+    loaded = GeneralTagDB.from_jsonl(jsonl)
+    assert loaded.tags["gotoh hitori"].category_path == ("캐릭터",)
+
+
+def test_inspect_prompt_keeps_original_order() -> None:
+    result = inspect_prompt("long hair, 1girl", knowledge_base=_kb())
+
+    assert [token.text for token in result.tokens] == ["long hair", "1girl"]
+    assert [token.section.value for token in result.tokens] == ["general", "count"]
+
+
+def test_animadex_csv_classifies_character_copyright_artist_and_core_tags(
+    tmp_path: Path,
+) -> None:
+    characters = tmp_path / "characters.csv"
+    artists = tmp_path / "artists.csv"
+    characters.write_text(
+        "character,copyright,trigger,core_tags,count,url\n"
+        'hatsune_miku,vocaloid,"hatsune miku, vocaloid",'
+        '"1girl, aqua eyes, twintails, detached sleeves",103500,'
+        "https://danbooru.donmai.us/posts?tags=hatsune_miku\n",
+        encoding="utf-8",
+    )
+    artists.write_text(
+        "artist,trigger,count,url\n"
+        "0-den,0-den,52,https://danbooru.donmai.us/posts?tags=0-den\n",
+        encoding="utf-8",
+    )
+
+    db = AnimaDexDB.from_csvs(characters_csv=characters, artists_csv=artists)
+    kb = PromptKnowledgeBase(animadex=db)
+    result = correct_prompt(
+        "twintails, vocaloid, @0-den, hatsune miku, 1girl",
+        knowledge_base=kb,
+    )
+
+    assert result.text == "1girl, hatsune miku, vocaloid, @0-den, twintails"
+    assert result.unknown_tags == ()
+    assert [token.section.value for token in result.tokens] == [
+        "count",
+        "character",
+        "copyright",
+        "artist",
+        "general",
+    ]
+
+
+def test_animadex_jsonl_index_round_trip(tmp_path: Path) -> None:
+    characters = tmp_path / "characters.csv"
+    artists = tmp_path / "artists.csv"
+    characters.write_text(
+        "character,copyright,trigger,core_tags,count,url\n"
+        'hatsune_miku,vocaloid,"hatsune miku, vocaloid","1girl",103500,\n',
+        encoding="utf-8",
+    )
+    artists.write_text(
+        "artist,trigger,count,url\n0-den,0-den,52,\n",
+        encoding="utf-8",
+    )
+
+    db = AnimaDexDB.from_csvs(characters_csv=characters, artists_csv=artists)
+    character_index, artist_index = db.write_jsonl(tmp_path / "index")
+    loaded = AnimaDexDB.from_jsonl(
+        character_index=character_index,
+        artist_index=artist_index,
+    )
+
+    assert "hatsune miku" in loaded.characters
+    assert "vocaloid" in loaded.copyrights
+    assert "1girl" in loaded.core_tags
+    assert "0-den" in loaded.artists
+
+
+class _FakeResponse:
+    def __init__(self, data: bytes):
+        self._data = data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self) -> bytes:
+        return self._data
+
+
+def test_animadex_token_store_round_trip(tmp_path: Path) -> None:
+    store = AnimaDexTokenStore(tmp_path / "token.json")
+    store.save(AnimaDexImportToken(token="secret", site="https://animadex.example"))
+
+    loaded = store.load()
+
+    assert loaded is not None
+    assert loaded.token == "secret"
+    assert loaded.site == "https://animadex.example"
+
+
+def test_animadex_import_downloads_csvs_to_import_dir(tmp_path: Path) -> None:
+    requests = []
+    manifest = (
+        b'{"csv":{"characters":"https://r2.example/characters.csv",'
+        b'"artists":"https://r2.example/artists.csv"}}'
+    )
+
+    def fake_open(request, timeout):
+        requests.append((request, timeout))
+        if request.full_url == "https://animadex.example/api/export/manifest?full=1":
+            return _FakeResponse(manifest)
+        if request.full_url == "https://r2.example/characters.csv":
+            return _FakeResponse(b"character,copyright,trigger,core_tags,count,url\n")
+        if request.full_url == "https://r2.example/artists.csv":
+            return _FakeResponse(b"artist,trigger,count,url\n")
+        raise AssertionError(request.full_url)
+
+    client = AnimaDexImportClient(
+        site="https://animadex.example",
+        token="secret",
+        opener=fake_open,
+    )
+
+    result = client.download_required_csvs(tmp_path / "animadex", full=True)
+
+    assert result.characters_csv == tmp_path / "animadex" / "import" / "characters.csv"
+    assert result.artists_csv == tmp_path / "animadex" / "import" / "artists.csv"
+    assert result.characters_csv.read_text(encoding="utf-8").startswith("character")
+    manifest_request = requests[0][0]
+    assert manifest_request.headers["X-export-token"] == "secret"

--- a/tests/test_anima_prompt.py
+++ b/tests/test_anima_prompt.py
@@ -12,6 +12,7 @@ from library.anima_prompt import (
     correct_prompt,
     inspect_prompt,
 )
+from library.anima_prompt.animadex import ANIMADEX_DEFAULT_DATA_DIR
 from library.anima_prompt.knowledge import parse_category_path
 
 
@@ -31,6 +32,10 @@ def _kb() -> PromptKnowledgeBase:
         for tag, path in tags.items()
     }
     return PromptKnowledgeBase(general=db)
+
+
+def test_animadex_default_data_dir_uses_ignored_models_folder() -> None:
+    assert ANIMADEX_DEFAULT_DATA_DIR == Path("models") / "animadex"
 
 
 def test_parse_description_category_path() -> None:

--- a/tests/test_gui_caption_history.py
+++ b/tests/test_gui_caption_history.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from gui.tabs.image_tab import _append_history, _read_history
+
+
+def test_caption_history_records_order_correction_reason(tmp_path):
+    caption = tmp_path / "sample.txt"
+
+    _append_history(caption, "1girl\nhatsune miku", reason="order_correction")
+    _append_history(caption, "1girl\nhatsune miku", reason="save")
+
+    history = _read_history(caption)
+
+    assert len(history) == 1
+    assert history[0]["text"] == "1girl\nhatsune miku"
+    assert history[0]["reason"] == "order_correction"


### PR DESCRIPTION
## Summary

ANIMA 캡션 순서 교정 코어와 GUI 진입점을 추가했습니다.

주요 변경 사항:

- `library/anima_prompt/`에 dependency-light prompt/caption correction core 추가
- AnimaDex `characters.csv` / `artists.csv` 기반 character / copyright / artist 판정 추가
- 이미지 데이터셋 뷰어에서 캡션 순서 교정 및 전체 적용 버튼 추가
- 캡션 순서 교정 전 내용을 caption history에 저장
- Settings에서 작가 태그 검증, `@no-artist` 삽입, 작가 태그 추가/예외 옵션 추가
- Models dialog에서 AnimaDex export token 저장, CSV 다운로드, JSONL index 생성 지원
- 모델 다운로드 목록에 AnimaDex 데이터베이스 상태 표시 추가

## Details

### Caption ordering

초기 목표는 ANIMA 캡션에서 prefix 역할을 하는 태그만 안정적으로 정렬하는 것입니다.

정렬 의도:

```text
quality / meta / year / safety
→ person count
→ character
→ copyright
→ artist
→ remaining tags in original order
```

AnimaDex는 다음 판정에만 사용합니다.

- character
- copyright / series
- artist

AnimaDex `core_tags`는 일반 Danbooru tag DB처럼 사용하지 않습니다. 일부 core tag만 일반 태그처럼 인식되면 artist 뒤쪽 tail 순서가 의도치 않게 바뀌기 때문입니다.

ANIMA 모델에서 쓰는 인원수 계열 태그는 작은 built-in set으로 처리합니다.

예:

- `1girl`
- `2girls`
- `6+girls`
- `1boy`
- `solo`
- `multiple girls`
- `no humans`

artist 뒤쪽 일반/unknown 태그는 서로 재정렬하지 않고 입력 순서를 유지합니다.

### GUI integration

데이터셋 뷰어에 캡션 순서 교정 버튼을 추가했습니다.

- 현재 캡션 교정
- 현재 디렉터리 전체 캡션 교정
- 교정 전 캡션 이력 저장

Settings에는 캡션 관련 옵션을 묶었습니다.

- 작가태그 검증
- `@no-artist` 삽입
- 작가태그 추가
- 작가태그 예외

### AnimaDex setup

Models dialog에 AnimaDex 데이터 준비 흐름을 추가했습니다.

GUI에서 가능한 작업:

- AnimaDex export token 입력
- token 저장
- `characters.csv`, `artists.csv` 다운로드
- `character_index.jsonl`, `artist_index.jsonl` 생성
- AnimaDex 데이터 준비 여부를 모델 목록에서 확인

사용자 안내에는 다음 링크를 직접 표시합니다.

```text
https://animadex.net
```

저장 위치:

```text
models/animadex/import/characters.csv
models/animadex/import/artists.csv
models/animadex/index/character_index.jsonl
models/animadex/index/artist_index.jsonl
```

## Validation

실행한 검증:

```bash
uv run ruff check gui/system_dialog.py gui/i18n/en.py gui/i18n/ko.py gui/i18n/ja.py gui/i18n/cn.py library/anima_prompt tests/test_anima_prompt.py
uv run python -m pytest tests/test_anima_prompt.py tests/test_gui_caption_history.py tests/test_gui_launch_speed.py -q
uv run python -m compileall library/anima_prompt gui/system_dialog.py gui/i18n tests/test_anima_prompt.py -q
```

결과:

```text
22 passed
```

추가 확인:

- `gui.system_dialog.ModelsDialog` import 확인
- 샘플 캡션에서 count / character / copyright / artist만 앞쪽으로 정렬되고, artist 이후 태그 순서가 유지되는 것 확인

## Not tested

AnimaDex 실제 다운로드는 사용자 export token과 네트워크 접근이 필요해서 로컬 GUI에서 직접 실행 검증하지는 않았습니다.