### PR TITLE
gui: add caption order correction

### DIFF
--- a/gui/_paths.py
+++ b/gui/_paths.py
@@ -22,6 +22,8 @@ GUI_SETTINGS_FILE = Path(__file__).resolve().parent / "gui_settings.json"
 # Default autotagger probability floor applied on top of the model's per-tag
 # F1 thresholds (see AnimaTagger.predict_caption min_confidence).
 DEFAULT_AUTOTAG_CONFIDENCE = 0.5
+DEFAULT_CAPTION_INSERT_NO_ARTIST = True
+DEFAULT_CAPTION_VALIDATE_ARTIST_TAGS = False
 # Defaults for the Dataset-tab grouping run (`curate-group`). Mirror the
 # library values (library.datasets.grouping.DEFAULT_*) so the GUI stays
 # torch-free; higher = tighter groups. See SettingsDialog + ImageViewerTab.

--- a/gui/app.py
+++ b/gui/app.py
@@ -40,6 +40,10 @@ from gui import (
 )
 from gui import daemon as gui_daemon
 from gui import theme as gui_theme
+from gui._paths import (
+    DEFAULT_CAPTION_INSERT_NO_ARTIST,
+    DEFAULT_CAPTION_VALIDATE_ARTIST_TAGS,
+)
 from gui.gpu_status import GpuStatusBar
 from gui.widgets import action_button
 from gui.i18n import (
@@ -229,6 +233,43 @@ class SettingsDialog(QDialog):
         conf_row.addWidget(self.conf_spin)
         conf_row.addStretch()
         prefs_lay.addLayout(conf_row)
+
+        self.caption_insert_no_artist = QCheckBox(
+            t("settings_caption_insert_no_artist")
+        )
+        self.caption_insert_no_artist.setToolTip(
+            t("settings_caption_insert_no_artist_tooltip")
+        )
+        self.caption_insert_no_artist.setChecked(
+            bool(
+                get_setting(
+                    "caption_insert_no_artist", DEFAULT_CAPTION_INSERT_NO_ARTIST
+                )
+            )
+        )
+        self.caption_insert_no_artist.toggled.connect(
+            lambda checked: set_setting("caption_insert_no_artist", bool(checked))
+        )
+        prefs_lay.addWidget(self.caption_insert_no_artist)
+
+        self.caption_validate_artist_tags = QCheckBox(
+            t("settings_caption_validate_artist_tags")
+        )
+        self.caption_validate_artist_tags.setToolTip(
+            t("settings_caption_validate_artist_tags_tooltip")
+        )
+        self.caption_validate_artist_tags.setChecked(
+            bool(
+                get_setting(
+                    "caption_validate_artist_tags",
+                    DEFAULT_CAPTION_VALIDATE_ARTIST_TAGS,
+                )
+            )
+        )
+        self.caption_validate_artist_tags.toggled.connect(
+            lambda checked: set_setting("caption_validate_artist_tags", bool(checked))
+        )
+        prefs_lay.addWidget(self.caption_validate_artist_tags)
 
         # Dataset-tab grouping (`curate-group`) tightness. Higher = tighter,
         # cleaner groups. Read at grouping time by ImageViewerTab._rebuild_groups

--- a/gui/i18n/cn.py
+++ b/gui/i18n/cn.py
@@ -376,6 +376,21 @@ STRINGS: dict[str, str] = {
     ),
     "caption_autotag_error": "自动标注失败：{err}",
     "caption_autotag_empty": "标注器未为该图像返回任何标签。",
+    "caption_correct": "校正顺序",
+    "caption_correct_tooltip": (
+        "使用 danbooru_tags_classified.csv 将标注按 ANIMA 推荐顺序重排，"
+        "并可按设置插入 @no-artist。"
+    ),
+    "caption_correct_visible": "校正当前列表",
+    "caption_correct_visible_confirm": "要校正当前列表中的 {n} 个标注吗？",
+    "caption_correct_visible_done": "已校正 {n} 个标注。",
+    "caption_correct_visible_failed": "已校正 {n} 个标注。\n\n失败:\n{err}",
+    "caption_correct_no_change": "没有需要校正的更改。",
+    "caption_correct_db_missing": (
+        "找不到 danbooru_tags_classified.csv。\n\n"
+        "请将它放到以下任一位置，或设置 ANIMA_DANBOORU_TAGS_CSV:\n{paths}"
+    ),
+    "caption_correct_db_failed": "标签 DB 加载失败: {err}",
     "caption_versions": "历史……",
     "caption_dirty_marker": " *",
     "caption_diff_stats": "(+{add} / −{rem})",
@@ -411,6 +426,16 @@ STRINGS: dict[str, str] = {
     "settings_autotag_confidence_tooltip": (
         "在打标器各标签阈值之上额外应用的概率下限（0–1）。"
         "数值越高，保留的标签越少但越可靠。默认 0.50。"
+    ),
+    "settings_caption_insert_no_artist": "校正时插入 @no-artist",
+    "settings_caption_insert_no_artist_tooltip": (
+        "如果校正后的标注没有作者标签，则在作者位置插入 @no-artist。"
+        "它只用于固定标注打乱边界，并会在分词前移除。"
+    ),
+    "settings_caption_validate_artist_tags": "用 DB 验证作者标签",
+    "settings_caption_validate_artist_tags_tooltip": (
+        "启用后，只有在 danbooru_tags_classified.csv 中分类为作者的 @标签"
+        "才会移动到作者位置。关闭时，所有 @开头的标签都视为作者标签。"
     ),
     "settings_group_match_frac": "分组严格度:",
     "settings_group_match_frac_tooltip": (

--- a/gui/i18n/cn.py
+++ b/gui/i18n/cn.py
@@ -388,7 +388,7 @@ STRINGS: dict[str, str] = {
     "caption_correct_no_change": "没有需要校正的更改。",
     "caption_correct_db_missing": (
         "找不到 danbooru_tags_classified.csv。\n\n"
-        "请将它放到以下任一位置，或设置 ANIMA_DANBOORU_TAGS_CSV:\n{paths}"
+        "请在模型窗口下载 Danbooru 标签 DB，或将它放到以下位置:\n{paths}"
     ),
     "caption_correct_db_failed": "标签 DB 加载失败: {err}",
     "caption_versions": "历史……",
@@ -506,8 +506,8 @@ STRINGS: dict[str, str] = {
     # Models dialog
     "models_title": "下载模型",
     "models_intro": "在下方选择模型组,或使用「全部下载」获取标准套件 "
-    "(Anima + SAM3 + MIT + PE)。文件保存于 models/ 下。",
-    "models_download_all": "全部下载 (Anima + SAM3 + MIT + PE)",
+    "(Anima + SAM3 + MIT + PE + 标签 DB)。文件保存于 models/ 下。",
+    "models_download_all": "全部下载 (Anima + SAM3 + MIT + PE + 标签 DB)",
     "models_download": "下载",
     "models_redownload": "重新下载",
     "models_installed": "✓ 已安装",
@@ -516,6 +516,7 @@ STRINGS: dict[str, str] = {
     "model_sam3": "SAM3 — 对话气泡蒙版",
     "model_mit": "MIT — 漫画文字蒙版",
     "model_pe": "PE-Core-L14-336 — 视觉编码器 (CMMD 验证 / DCW)",
+    "model_danbooru_tags": "Danbooru 标签 DB — 标注顺序校正",
     # HuggingFace 认证（模型对话框）
     "models_hf_token_placeholder": "粘贴你的 HuggingFace 令牌 (hf_…)",
     "models_hf_authenticate": "认证",

--- a/gui/i18n/en.py
+++ b/gui/i18n/en.py
@@ -453,7 +453,7 @@ STRINGS: dict[str, str] = {
     "caption_correct_no_change": "No caption changes to apply.",
     "caption_correct_db_missing": (
         "danbooru_tags_classified.csv was not found.\n\n"
-        "Place it in one of these locations, or set ANIMA_DANBOORU_TAGS_CSV:\n{paths}"
+        "Download the Danbooru tag DB from the Models dialog, or place it here:\n{paths}"
     ),
     "caption_correct_db_failed": "Failed to load tag DB: {err}",
     "caption_versions": "Versions…",
@@ -576,8 +576,8 @@ STRINGS: dict[str, str] = {
     # Models dialog
     "models_title": "Download Models",
     "models_intro": "Pick a model group below or use 'Download all' for the standard set "
-    "(Anima + SAM3 + MIT + PE). Files are saved under models/.",
-    "models_download_all": "Download all (Anima + SAM3 + MIT + PE)",
+    "(Anima + SAM3 + MIT + PE + tag DB). Files are saved under models/.",
+    "models_download_all": "Download all (Anima + SAM3 + MIT + PE + tag DB)",
     "models_download": "Download",
     "models_redownload": "Re-download",
     "models_installed": "✓ Installed",
@@ -590,6 +590,7 @@ STRINGS: dict[str, str] = {
     "model_sam3": "SAM3 — text-bubble masking",
     "model_mit": "MIT — manga text masking",
     "model_pe": "PE-Core-L14-336 — vision encoder (CMMD validation / DCW)",
+    "model_danbooru_tags": "Danbooru tag DB — caption order correction",
     # HuggingFace authentication (Models dialog)
     "models_hf_token_placeholder": "Paste your HuggingFace token (hf_…)",
     "models_hf_authenticate": "Authenticate",

--- a/gui/i18n/en.py
+++ b/gui/i18n/en.py
@@ -441,6 +441,21 @@ STRINGS: dict[str, str] = {
     ),
     "caption_autotag_error": "Autotag failed: {err}",
     "caption_autotag_empty": "The tagger returned no tags for this image.",
+    "caption_correct": "Correct order",
+    "caption_correct_tooltip": (
+        "Use danbooru_tags_classified.csv to reorder this caption into the "
+        "recommended ANIMA order, optionally inserting @no-artist."
+    ),
+    "caption_correct_visible": "Correct current list",
+    "caption_correct_visible_confirm": "Correct {n} caption(s) in the current list?",
+    "caption_correct_visible_done": "Corrected {n} caption(s).",
+    "caption_correct_visible_failed": "Corrected {n} caption(s).\n\nFailed:\n{err}",
+    "caption_correct_no_change": "No caption changes to apply.",
+    "caption_correct_db_missing": (
+        "danbooru_tags_classified.csv was not found.\n\n"
+        "Place it in one of these locations, or set ANIMA_DANBOORU_TAGS_CSV:\n{paths}"
+    ),
+    "caption_correct_db_failed": "Failed to load tag DB: {err}",
     "caption_versions": "Versions…",
     "caption_dirty_marker": " *",
     "caption_diff_stats": "(+{add} / −{rem})",
@@ -477,6 +492,16 @@ STRINGS: dict[str, str] = {
     "settings_autotag_confidence_tooltip": (
         "Extra probability floor (0–1) applied on top of the tagger's per-tag "
         "thresholds. Higher = fewer, more confident tags. Default 0.50."
+    ),
+    "settings_caption_insert_no_artist": "Insert @no-artist during caption correction",
+    "settings_caption_insert_no_artist_tooltip": (
+        "If the corrected caption has no artist tag, insert @no-artist at the "
+        "artist position. It only anchors caption shuffle and is stripped before tokenization."
+    ),
+    "settings_caption_validate_artist_tags": "Validate artist tags with DB",
+    "settings_caption_validate_artist_tags_tooltip": (
+        "When enabled, only @tags classified as artists in danbooru_tags_classified.csv "
+        "move to the artist position. When disabled, any @tag is treated as an artist tag."
     ),
     "settings_group_match_frac": "Grouping tightness:",
     "settings_group_match_frac_tooltip": (

--- a/gui/i18n/ja.py
+++ b/gui/i18n/ja.py
@@ -403,7 +403,7 @@ STRINGS: dict[str, str] = {
     "caption_correct_no_change": "補正する変更はありません。",
     "caption_correct_db_missing": (
         "danbooru_tags_classified.csv が見つかりません。\n\n"
-        "次の場所のいずれかに置くか、ANIMA_DANBOORU_TAGS_CSV を設定してください:\n{paths}"
+        "モデル画面から Danbooru タグ DB をダウンロードするか、次の場所に置いてください:\n{paths}"
     ),
     "caption_correct_db_failed": "タグ DB の読み込みに失敗: {err}",
     "caption_versions": "履歴…",
@@ -525,8 +525,8 @@ STRINGS: dict[str, str] = {
     # Models dialog
     "models_title": "モデルのダウンロード",
     "models_intro": "以下からモデルグループを選択するか、「すべてダウンロード」で標準セット "
-    "(Anima + SAM3 + MIT + PE) をダウンロードします。ファイルは models/ に保存されます。",
-    "models_download_all": "すべてダウンロード (Anima + SAM3 + MIT + PE)",
+    "(Anima + SAM3 + MIT + PE + タグ DB) をダウンロードします。ファイルは models/ に保存されます。",
+    "models_download_all": "すべてダウンロード (Anima + SAM3 + MIT + PE + タグ DB)",
     "models_download": "ダウンロード",
     "models_redownload": "再ダウンロード",
     "models_installed": "✓ インストール済み",
@@ -535,6 +535,7 @@ STRINGS: dict[str, str] = {
     "model_sam3": "SAM3 — テキストバブルマスキング",
     "model_mit": "MIT — 漫画テキストマスキング",
     "model_pe": "PE-Core-L14-336 — ビジョンエンコーダー (CMMD 検証 / DCW)",
+    "model_danbooru_tags": "Danbooru タグ DB — キャプション順序補正",
     # HuggingFace 認証 (モデルダイアログ)
     "models_hf_token_placeholder": "HuggingFace トークンを貼り付けてください (hf_…)",
     "models_hf_authenticate": "認証",

--- a/gui/i18n/ja.py
+++ b/gui/i18n/ja.py
@@ -391,6 +391,21 @@ STRINGS: dict[str, str] = {
     ),
     "caption_autotag_error": "自動タグ付けに失敗しました: {err}",
     "caption_autotag_empty": "タガーはこの画像のタグを返しませんでした。",
+    "caption_correct": "順序補正",
+    "caption_correct_tooltip": (
+        "danbooru_tags_classified.csv を使ってキャプションを ANIMA 推奨順に並べ替え、"
+        "設定に応じて @no-artist を挿入します。"
+    ),
+    "caption_correct_visible": "現在の一覧を一括補正",
+    "caption_correct_visible_confirm": "現在の一覧のキャプション {n} 件を補正しますか？",
+    "caption_correct_visible_done": "キャプション {n} 件を補正しました。",
+    "caption_correct_visible_failed": "キャプション {n} 件を補正しました。\n\n失敗:\n{err}",
+    "caption_correct_no_change": "補正する変更はありません。",
+    "caption_correct_db_missing": (
+        "danbooru_tags_classified.csv が見つかりません。\n\n"
+        "次の場所のいずれかに置くか、ANIMA_DANBOORU_TAGS_CSV を設定してください:\n{paths}"
+    ),
+    "caption_correct_db_failed": "タグ DB の読み込みに失敗: {err}",
     "caption_versions": "履歴…",
     "caption_dirty_marker": " *",
     "caption_diff_stats": "(+{add} / −{rem})",
@@ -426,6 +441,16 @@ STRINGS: dict[str, str] = {
     "settings_autotag_confidence_tooltip": (
         "タガーのタグ別しきい値に追加で適用する確率の下限（0–1）です。"
         "高いほど確信度の高いタグだけが少数残ります。既定値 0.50。"
+    ),
+    "settings_caption_insert_no_artist": "補正時に @no-artist を挿入",
+    "settings_caption_insert_no_artist_tooltip": (
+        "補正後のキャプションに作家タグがない場合、作家位置に @no-artist を入れます。"
+        "キャプションシャッフルの境界としてのみ使われ、トークン化前に除去されます。"
+    ),
+    "settings_caption_validate_artist_tags": "作家タグを DB で検証",
+    "settings_caption_validate_artist_tags_tooltip": (
+        "有効にすると danbooru_tags_classified.csv で作家に分類された @タグだけを"
+        "作家位置へ移動します。無効なら @ で始まるタグを作家タグとして扱います。"
     ),
     "settings_group_match_frac": "グループ化の厳しさ:",
     "settings_group_match_frac_tooltip": (

--- a/gui/i18n/ko.py
+++ b/gui/i18n/ko.py
@@ -429,6 +429,21 @@ STRINGS: dict[str, str] = {
     ),
     "caption_autotag_error": "자동 태깅 실패: {err}",
     "caption_autotag_empty": "태거가 이 이미지에서 태그를 찾지 못했습니다.",
+    "caption_correct": "순서 교정",
+    "caption_correct_tooltip": (
+        "danbooru_tags_classified.csv를 사용해 캡션을 ANIMA 권장 순서로 "
+        "재배치하고, 설정에 따라 @no-artist를 삽입합니다."
+    ),
+    "caption_correct_visible": "현재 목록 전체 교정",
+    "caption_correct_visible_confirm": "현재 목록의 캡션 {n}개를 교정할까요?",
+    "caption_correct_visible_done": "캡션 {n}개를 교정했습니다.",
+    "caption_correct_visible_failed": "캡션 {n}개를 교정했습니다.\n\n실패:\n{err}",
+    "caption_correct_no_change": "교정할 변경사항이 없습니다.",
+    "caption_correct_db_missing": (
+        "danbooru_tags_classified.csv를 찾을 수 없습니다.\n\n"
+        "다음 위치 중 하나에 배치하거나 ANIMA_DANBOORU_TAGS_CSV 환경변수로 지정하세요:\n{paths}"
+    ),
+    "caption_correct_db_failed": "태그 DB 로드 실패: {err}",
     "caption_versions": "이력…",
     "caption_dirty_marker": " *",
     "caption_diff_stats": "(+{add} / −{rem})",
@@ -465,6 +480,16 @@ STRINGS: dict[str, str] = {
     "settings_autotag_confidence_tooltip": (
         "태거의 태그별 임계값 위에 추가로 적용되는 확률 하한(0–1)입니다. "
         "높을수록 더 확실한 태그만 적게 남습니다. 기본값 0.50."
+    ),
+    "settings_caption_insert_no_artist": "캡션 교정 시 @no-artist 삽입",
+    "settings_caption_insert_no_artist_tooltip": (
+        "교정 결과에 작가 태그가 없으면 작가 위치에 @no-artist를 넣습니다. "
+        "캡션 셔플 경계로만 쓰이며 토큰화 직전에 제거됩니다."
+    ),
+    "settings_caption_validate_artist_tags": "작가 태그를 DB로 검증",
+    "settings_caption_validate_artist_tags_tooltip": (
+        "켜면 danbooru_tags_classified.csv에서 작가로 분류된 @태그만 작가 위치로 "
+        "옮깁니다. 끄면 @로 시작하는 태그를 작가 태그로 취급합니다."
     ),
     "settings_group_match_frac": "그룹화 엄격도:",
     "settings_group_match_frac_tooltip": (

--- a/gui/i18n/ko.py
+++ b/gui/i18n/ko.py
@@ -441,7 +441,7 @@ STRINGS: dict[str, str] = {
     "caption_correct_no_change": "교정할 변경사항이 없습니다.",
     "caption_correct_db_missing": (
         "danbooru_tags_classified.csv를 찾을 수 없습니다.\n\n"
-        "다음 위치 중 하나에 배치하거나 ANIMA_DANBOORU_TAGS_CSV 환경변수로 지정하세요:\n{paths}"
+        "모델 창에서 Danbooru 태그 DB를 다운로드하거나 다음 위치에 배치하세요:\n{paths}"
     ),
     "caption_correct_db_failed": "태그 DB 로드 실패: {err}",
     "caption_versions": "이력…",
@@ -564,8 +564,8 @@ STRINGS: dict[str, str] = {
     # Models dialog
     "models_title": "모델 다운로드",
     "models_intro": "아래에서 모델 그룹을 선택하거나 '전체 다운로드'로 표준 세트 "
-    "(Anima + SAM3 + MIT + PE)를 받으세요. 파일은 models/ 아래에 저장됩니다.",
-    "models_download_all": "전체 다운로드 (Anima + SAM3 + MIT + PE)",
+    "(Anima + SAM3 + MIT + PE + 태그 DB)를 받으세요. 파일은 models/ 아래에 저장됩니다.",
+    "models_download_all": "전체 다운로드 (Anima + SAM3 + MIT + PE + 태그 DB)",
     "models_download": "다운로드",
     "models_redownload": "재다운로드",
     "models_installed": "✓ 설치됨",
@@ -574,6 +574,7 @@ STRINGS: dict[str, str] = {
     "model_sam3": "SAM3 — 말풍선 마스킹",
     "model_mit": "MIT — 만화 텍스트 마스킹",
     "model_pe": "PE-Core-L14-336 — 비전 인코더 (CMMD 검증 / DCW)",
+    "model_danbooru_tags": "Danbooru 태그 DB — 캡션 순서 교정",
     # HuggingFace 인증 (모델 다이얼로그)
     "models_hf_token_placeholder": "HuggingFace 토큰을 붙여넣으세요 (hf_…)",
     "models_hf_authenticate": "인증",

--- a/gui/system_dialog.py
+++ b/gui/system_dialog.py
@@ -58,6 +58,11 @@ _MODEL_GROUPS: list[tuple[str, str, list[str]]] = [
             "models/pe/PE-Spatial-B16-512.pt",
         ],
     ),
+    (
+        "danbooru-tags",
+        "model_danbooru_tags",
+        ["models/danbooru_tags_classified.csv"],
+    ),
 ]
 
 

--- a/gui/tabs/image_tab.py
+++ b/gui/tabs/image_tab.py
@@ -75,11 +75,23 @@ from gui import (
     get_setting,
 )
 from gui import daemon as gui_daemon
+from gui._paths import (
+    DEFAULT_CAPTION_INSERT_NO_ARTIST,
+    DEFAULT_CAPTION_VALIDATE_ARTIST_TAGS,
+)
 from gui._job_mixin import DaemonJobMixin
 from gui.i18n import t
 from gui.progress import TqdmProgressTracker, make_progress_bar
 from gui.theme import tok
 from gui.widgets import apply_variant
+from library.captioning.correction import (
+    CaptionCorrectionOptions,
+    TagKnowledgeBase,
+    correct_caption,
+    default_tag_csv_candidates,
+    find_tag_csv,
+    load_tag_knowledge_base,
+)
 from library.datasets.curation_actions import (
     load_curation_decisions,
     move_linked_files,
@@ -694,6 +706,8 @@ class ImageViewerTab(DaemonJobMixin, LazyTabMixin, QWidget):
         self._gpu_watch_timer = QTimer(self)
         self._gpu_watch_timer.setInterval(_AUTOTAG_GPU_WATCH_MS)
         self._gpu_watch_timer.timeout.connect(self._autotag_gpu_watch_tick)
+        self._caption_kb: TagKnowledgeBase | None = None
+        self._caption_kb_source: Path | None = None
         # Make sure the resident worker (and its VRAM) dies with the app.
         _app = QApplication.instance()
         if _app is not None:
@@ -887,11 +901,18 @@ class ImageViewerTab(DaemonJobMixin, LazyTabMixin, QWidget):
         self.autotag_btn.setToolTip(t("caption_autotag_tooltip"))
         apply_variant(self.autotag_btn, "info")
         self.autotag_btn.clicked.connect(self._run_autotag)
+        self.caption_correct_btn = self._make_button_with_menu(
+            t("caption_correct"),
+            t("caption_correct_tooltip"),
+            self._correct_current_caption,
+            [(t("caption_correct_visible"), self._correct_visible_captions)],
+        )
         self.versions_btn = QPushButton(t("caption_versions"))
         self.versions_btn.clicked.connect(self._open_versions)
         cap_head.addWidget(self.save_btn)
         cap_head.addWidget(self.revert_btn)
         cap_head.addWidget(self.autotag_btn)
+        cap_head.addWidget(self.caption_correct_btn)
         cap_head.addWidget(self.versions_btn)
         rl.addLayout(cap_head)
 
@@ -1203,6 +1224,129 @@ class ImageViewerTab(DaemonJobMixin, LazyTabMixin, QWidget):
         self._set_caption_text(combined)
         self._refresh_buttons()
         self._refresh_inline_diff()
+
+    def _caption_correction_options(self) -> CaptionCorrectionOptions:
+        return CaptionCorrectionOptions(
+            insert_no_artist=bool(
+                get_setting(
+                    "caption_insert_no_artist", DEFAULT_CAPTION_INSERT_NO_ARTIST
+                )
+            ),
+            validate_artist_tags=bool(
+                get_setting(
+                    "caption_validate_artist_tags",
+                    DEFAULT_CAPTION_VALIDATE_ARTIST_TAGS,
+                )
+            ),
+        )
+
+    def _load_caption_kb(self) -> TagKnowledgeBase | None:
+        csv_path = find_tag_csv(ROOT)
+        if csv_path is None:
+            candidates = "\n".join(
+                f"  {path}" for path in default_tag_csv_candidates(ROOT)
+            )
+            QMessageBox.warning(
+                self,
+                t("error"),
+                t("caption_correct_db_missing", paths=candidates),
+            )
+            return None
+        if self._caption_kb is not None and self._caption_kb_source == csv_path:
+            return self._caption_kb
+        try:
+            self._caption_kb = load_tag_knowledge_base(csv_path)
+            self._caption_kb_source = csv_path
+        except (OSError, ValueError) as exc:
+            QMessageBox.warning(
+                self, t("error"), t("caption_correct_db_failed", err=str(exc))
+            )
+            self._caption_kb = None
+            self._caption_kb_source = None
+        return self._caption_kb
+
+    def _correct_current_caption(self) -> None:
+        if self._current_caption_path is None:
+            return
+        kb = self._load_caption_kb()
+        if kb is None:
+            return
+        result = correct_caption(
+            self.cap.toPlainText(),
+            kb,
+            options=self._caption_correction_options(),
+        )
+        if not result.changed:
+            QMessageBox.information(self, "", t("caption_correct_no_change"))
+            return
+        self._set_caption_text(result.text)
+        self._refresh_buttons()
+        self._refresh_inline_diff()
+
+    def _correct_visible_captions(self) -> None:
+        if not self._images:
+            return
+        if not self._confirm_discard_if_dirty():
+            return
+        kb = self._load_caption_kb()
+        if kb is None:
+            return
+        reply = QMessageBox.question(
+            self,
+            t("caption_correct"),
+            t("caption_correct_visible_confirm", n=len(self._images)),
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        if reply != QMessageBox.Yes:
+            return
+
+        changed = 0
+        failed: list[str] = []
+        options = self._caption_correction_options()
+        for image_path in self._images:
+            caption_path = image_path.with_suffix(".txt")
+            if not caption_path.exists():
+                continue
+            try:
+                old_text = caption_path.read_text(encoding="utf-8")
+                result = correct_caption(old_text, kb, options=options)
+                if not result.changed:
+                    continue
+                _append_history(caption_path, old_text)
+                caption_path.write_text(result.text, encoding="utf-8")
+                changed += 1
+            except OSError as exc:
+                failed.append(f"{caption_path}: {exc}")
+
+        if (
+            self._current_caption_path is not None
+            and self._current_caption_path.exists()
+        ):
+            try:
+                self._disk_text = self._current_caption_path.read_text(
+                    encoding="utf-8"
+                )
+            except OSError:
+                pass
+            self._set_caption_text(self._disk_text)
+            self._refresh_buttons()
+            self._refresh_inline_diff()
+
+        if failed:
+            QMessageBox.warning(
+                self,
+                t("error"),
+                t(
+                    "caption_correct_visible_failed",
+                    n=changed,
+                    err="\n".join(failed[:10]),
+                ),
+            )
+        else:
+            QMessageBox.information(
+                self, "", t("caption_correct_visible_done", n=changed)
+            )
 
     def _finish_autotag_request(self) -> None:
         """Clear the in-flight state and re-arm the button after a reply."""

--- a/gui/tabs/image_tab.py
+++ b/gui/tabs/image_tab.py
@@ -708,6 +708,7 @@ class ImageViewerTab(DaemonJobMixin, LazyTabMixin, QWidget):
         self._gpu_watch_timer.timeout.connect(self._autotag_gpu_watch_tick)
         self._caption_kb: TagKnowledgeBase | None = None
         self._caption_kb_source: Path | None = None
+        self._caption_kb_mtime: float | None = None
         # Make sure the resident worker (and its VRAM) dies with the app.
         _app = QApplication.instance()
         if _app is not None:
@@ -906,6 +907,7 @@ class ImageViewerTab(DaemonJobMixin, LazyTabMixin, QWidget):
             t("caption_correct_tooltip"),
             self._correct_current_caption,
             [(t("caption_correct_visible"), self._correct_visible_captions)],
+            variant="info",
         )
         self.versions_btn = QPushButton(t("caption_versions"))
         self.versions_btn.clicked.connect(self._open_versions)
@@ -977,7 +979,7 @@ class ImageViewerTab(DaemonJobMixin, LazyTabMixin, QWidget):
             self._load_dir(self.dc.currentText())
 
     def _make_button_with_menu(
-        self, text: str, tooltip: str, clicked_cb, actions
+        self, text: str, tooltip: str, clicked_cb, actions, *, variant: str | None = None
     ) -> QWidget:
         host = QWidget()
         row = QHBoxLayout(host)
@@ -986,6 +988,8 @@ class ImageViewerTab(DaemonJobMixin, LazyTabMixin, QWidget):
 
         main_btn = QPushButton(text)
         main_btn.setToolTip(tooltip)
+        if variant is not None:
+            apply_variant(main_btn, variant)
         main_btn.clicked.connect(lambda _checked=False: clicked_cb())
         row.addWidget(main_btn)
 
@@ -1252,17 +1256,30 @@ class ImageViewerTab(DaemonJobMixin, LazyTabMixin, QWidget):
                 t("caption_correct_db_missing", paths=candidates),
             )
             return None
-        if self._caption_kb is not None and self._caption_kb_source == csv_path:
+        try:
+            mtime = csv_path.stat().st_mtime
+        except OSError as exc:
+            QMessageBox.warning(
+                self, t("error"), t("caption_correct_db_failed", err=str(exc))
+            )
+            return None
+        if (
+            self._caption_kb is not None
+            and self._caption_kb_source == csv_path
+            and self._caption_kb_mtime == mtime
+        ):
             return self._caption_kb
         try:
             self._caption_kb = load_tag_knowledge_base(csv_path)
             self._caption_kb_source = csv_path
+            self._caption_kb_mtime = mtime
         except (OSError, ValueError) as exc:
             QMessageBox.warning(
                 self, t("error"), t("caption_correct_db_failed", err=str(exc))
             )
             self._caption_kb = None
             self._caption_kb_source = None
+            self._caption_kb_mtime = None
         return self._caption_kb
 
     def _correct_current_caption(self) -> None:

--- a/library/captioning/correction.py
+++ b/library/captioning/correction.py
@@ -35,9 +35,6 @@ _ANIMA_PERSON_TAGS = frozenset(
     {
         "solo",
         "no humans",
-        "multiple girls",
-        "multiple boys",
-        "multiple others",
     }
 )
 
@@ -230,6 +227,8 @@ def _kind_from_category(category_path: str, numeric_category: str) -> str:
     numeric_kind = _DANBOORU_NUMERIC_CATEGORIES.get(numeric_category.strip())
     if numeric_kind is not None:
         return numeric_kind
+    # Localsmile's fallback category path is Korean; numeric Danbooru category is
+    # preferred above so this only helps non-standard rows.
     if category_path:
         root = category_path.split(">")[0].strip()
         if root == "작가":

--- a/library/captioning/correction.py
+++ b/library/captioning/correction.py
@@ -1,0 +1,270 @@
+"""Caption ordering helpers for Anima-style Danbooru captions.
+
+Pure-stdlib and GUI-safe: the tag database is loaded lazily from a local CSV
+only when correction is requested.
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from library.captioning.taxonomy import CAPTION_RATINGS, is_artist_tag, is_count_tag
+
+
+_CATEGORY_RE = re.compile(r"^\s*\[([^\]]+)\]")
+_SPACE_RE = re.compile(r"\s+")
+
+# Fallback path works for this source tree without importing gui. GUI passes
+# ROOT explicitly so installed layouts can keep the CSV under models/.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_DANBOORU_NUMERIC_CATEGORIES = {
+    "0": "general",
+    "1": "artist",
+    "3": "copyright",
+    "4": "character",
+    "5": "meta",
+}
+
+_ANIMA_PERSON_TAGS = frozenset(
+    {
+        "solo",
+        "no humans",
+        "multiple girls",
+        "multiple boys",
+        "multiple others",
+    }
+)
+
+
+@dataclass(frozen=True)
+class CaptionCorrectionOptions:
+    """User-visible caption correction switches."""
+
+    insert_no_artist: bool = True
+    validate_artist_tags: bool = False
+
+
+@dataclass(frozen=True)
+class CaptionCorrectionResult:
+    text: str
+    changed: bool
+    inserted_no_artist: bool
+    unknown_tags: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class TagInfo:
+    name: str
+    kind: str
+    category_path: str
+
+
+class TagKnowledgeBase:
+    """Minimal Danbooru tag classifier backed by ``danbooru_tags_classified.csv``."""
+
+    def __init__(self, tags: dict[str, TagInfo], source: Path):
+        self.tags = tags
+        self.source = source
+
+    def classify(self, tag: str) -> str | None:
+        info = self.tags.get(tag_key(tag))
+        return info.kind if info else None
+
+    def has_artist(self, tag: str) -> bool:
+        bare = tag[1:] if tag.startswith("@") else tag
+        return self.classify(bare) == "artist"
+
+
+def default_tag_csv_candidates(root: Path | None = None) -> list[Path]:
+    """Likely local CSV locations, in priority order."""
+
+    paths: list[Path] = []
+    env = os.environ.get("ANIMA_DANBOORU_TAGS_CSV")
+    if env:
+        paths.append(Path(env))
+    if root is not None:
+        paths.extend(
+            [
+                root / "models" / "danbooru_tags_classified.csv",
+                root / "danbooru_tags_classified.csv",
+                root.parent / "danbooru_tags_classified.csv",
+            ]
+        )
+    paths.extend(
+        [
+            _REPO_ROOT / "models" / "danbooru_tags_classified.csv",
+            _REPO_ROOT / "danbooru_tags_classified.csv",
+            _REPO_ROOT.parent / "danbooru_tags_classified.csv",
+        ]
+    )
+
+    out: list[Path] = []
+    seen: set[Path] = set()
+    for path in paths:
+        try:
+            key = path.resolve()
+        except OSError:
+            key = path
+        if key not in seen:
+            seen.add(key)
+            out.append(path)
+    return out
+
+
+def find_tag_csv(root: Path | None = None) -> Path | None:
+    for path in default_tag_csv_candidates(root):
+        if path.exists():
+            return path
+    return None
+
+
+def load_tag_knowledge_base(path: str | Path) -> TagKnowledgeBase:
+    csv_path = Path(path)
+    tags: dict[str, TagInfo] = {}
+    with csv_path.open("r", encoding="utf-8-sig", newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            raw_name = str(row.get("name") or "").strip()
+            if not raw_name:
+                continue
+            category_path = _description_category_path(str(row.get("description") or ""))
+            kind = _kind_from_category(category_path, str(row.get("category") or ""))
+            tags[tag_key(raw_name)] = TagInfo(
+                name=normalize_tag(raw_name),
+                kind=kind,
+                category_path=category_path,
+            )
+    return TagKnowledgeBase(tags=tags, source=csv_path)
+
+
+def normalize_tag(tag: str) -> str:
+    tag = tag.strip().replace("_", " ").lower()
+    return _SPACE_RE.sub(" ", tag)
+
+
+def tag_key(tag: str) -> str:
+    tag = normalize_tag(tag)
+    if tag.startswith("@"):
+        tag = tag[1:]
+    return tag.replace(" ", "_")
+
+
+def correct_caption(
+    text: str,
+    kb: TagKnowledgeBase,
+    *,
+    options: CaptionCorrectionOptions | None = None,
+) -> CaptionCorrectionResult:
+    options = options or CaptionCorrectionOptions()
+    tags = _parse_tags(text)
+    if not tags:
+        return CaptionCorrectionResult(text="", changed=bool(text.strip()), inserted_no_artist=False, unknown_tags=())
+
+    buckets: dict[str, list[str]] = {
+        "meta": [],
+        "count": [],
+        "character": [],
+        "copyright": [],
+        "artist": [],
+        "general": [],
+    }
+    unknown: list[str] = []
+    seen: set[str] = set()
+
+    for tag in tags:
+        key = tag_key(tag)
+        if key in seen:
+            continue
+        seen.add(key)
+        kind = _classify_tag(tag, kb, options)
+        if kind is None:
+            unknown.append(tag)
+            kind = "general"
+        buckets[kind].append(tag)
+
+    inserted_no_artist = False
+    if options.insert_no_artist and not buckets["artist"]:
+        buckets["artist"].append("@no-artist")
+        inserted_no_artist = True
+
+    ordered = [
+        *buckets["meta"],
+        *buckets["count"],
+        *buckets["character"],
+        *buckets["copyright"],
+        *buckets["artist"],
+        *buckets["general"],
+    ]
+    corrected = ", ".join(ordered)
+    return CaptionCorrectionResult(
+        text=corrected,
+        changed=corrected != text.strip(),
+        inserted_no_artist=inserted_no_artist,
+        unknown_tags=tuple(unknown),
+    )
+
+
+def _parse_tags(text: str) -> list[str]:
+    raw = text.replace("\n", ",").split(",")
+    return [normalize_tag(tag) for tag in raw if tag.strip()]
+
+
+def _classify_tag(
+    tag: str, kb: TagKnowledgeBase, options: CaptionCorrectionOptions
+) -> str | None:
+    if tag == "@no-artist":
+        return "artist"
+    if is_artist_tag(tag):
+        if not options.validate_artist_tags or kb.has_artist(tag):
+            return "artist"
+        return "general"
+    if tag in CAPTION_RATINGS or _is_year_tag(tag):
+        return "meta"
+    if is_count_tag(tag) or tag in _ANIMA_PERSON_TAGS:
+        return "count"
+    return kb.classify(tag)
+
+
+def _description_category_path(description: str) -> str:
+    match = _CATEGORY_RE.match(description)
+    if not match:
+        return ""
+    return normalize_tag(match.group(1).replace(">", " > "))
+
+
+def _kind_from_category(category_path: str, numeric_category: str) -> str:
+    numeric_kind = _DANBOORU_NUMERIC_CATEGORIES.get(numeric_category.strip())
+    if numeric_kind is not None:
+        return numeric_kind
+    if category_path:
+        root = category_path.split(">")[0].strip()
+        if root == "작가":
+            return "artist"
+        if root == "캐릭터":
+            return "character"
+        if root == "작품":
+            return "copyright"
+        if root == "메타":
+            return "meta"
+        if category_path.startswith("인물 > 인원수"):
+            return "count"
+    return "general"
+
+
+def _is_year_tag(tag: str) -> bool:
+    return len(tag) == 4 and tag.isdigit() and 1900 <= int(tag) <= 2100
+
+
+def correct_many(
+    captions: Iterable[tuple[Path, str]],
+    kb: TagKnowledgeBase,
+    *,
+    options: CaptionCorrectionOptions | None = None,
+) -> list[tuple[Path, CaptionCorrectionResult]]:
+    return [(path, correct_caption(text, kb, options=options)) for path, text in captions]

--- a/library/captioning/correction.py
+++ b/library/captioning/correction.py
@@ -85,24 +85,12 @@ def default_tag_csv_candidates(root: Path | None = None) -> list[Path]:
     """Likely local CSV locations, in priority order."""
 
     paths: list[Path] = []
+    if root is not None:
+        paths.append(root / "models" / "danbooru_tags_classified.csv")
+    paths.append(_REPO_ROOT / "models" / "danbooru_tags_classified.csv")
     env = os.environ.get("ANIMA_DANBOORU_TAGS_CSV")
     if env:
         paths.append(Path(env))
-    if root is not None:
-        paths.extend(
-            [
-                root / "models" / "danbooru_tags_classified.csv",
-                root / "danbooru_tags_classified.csv",
-                root.parent / "danbooru_tags_classified.csv",
-            ]
-        )
-    paths.extend(
-        [
-            _REPO_ROOT / "models" / "danbooru_tags_classified.csv",
-            _REPO_ROOT / "danbooru_tags_classified.csv",
-            _REPO_ROOT.parent / "danbooru_tags_classified.csv",
-        ]
-    )
 
     out: list[Path] = []
     seen: set[Path] = set()

--- a/scripts/tasks/downloads.py
+++ b/scripts/tasks/downloads.py
@@ -17,9 +17,18 @@ failures at the end.
 from __future__ import annotations
 
 import shutil
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 from ._common import ROOT, run
+
+
+DANBOORU_TAGS_PATH = ROOT / "models" / "danbooru_tags_classified.csv"
+DANBOORU_TAGS_URLS = (
+    "https://github.com/sorryhyun/anima_lora/releases/latest/download/danbooru_tags_classified.csv",
+    "https://raw.githubusercontent.com/sorryhyun/anima_lora/main/models/danbooru_tags_classified.csv",
+)
 
 
 def _present(paths: list[Path]) -> bool:
@@ -104,6 +113,35 @@ def cmd_download_tagger(_extra):
     )
 
 
+def cmd_download_danbooru_tags(_extra):
+    """Download the classified Danbooru tag table used by caption correction."""
+
+    if _skip("Danbooru classified tags", [DANBOORU_TAGS_PATH], _extra):
+        return
+    DANBOORU_TAGS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp = DANBOORU_TAGS_PATH.with_suffix(".csv.tmp")
+    last_error = ""
+    for url in DANBOORU_TAGS_URLS:
+        print(f"  download {url}")
+        try:
+            req = urllib.request.Request(url, headers={"User-Agent": "anima-lora"})
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                tmp.write_bytes(resp.read())
+            if tmp.stat().st_size <= 0:
+                raise OSError("downloaded file is empty")
+            tmp.replace(DANBOORU_TAGS_PATH)
+            print(f"  ✓ wrote {DANBOORU_TAGS_PATH}")
+            return
+        except (OSError, urllib.error.URLError) as exc:
+            last_error = str(exc)
+            if tmp.exists():
+                tmp.unlink()
+            print(f"  ✗ failed: {last_error}")
+    raise SystemExit(
+        "failed to download danbooru_tags_classified.csv from sorryhyun/anima_lora"
+    )
+
+
 def cmd_download_mit(_extra):
     dst = ROOT / "models" / "mit"
     if _skip("MIT", [dst / "model.pth"], _extra):
@@ -170,6 +208,7 @@ def cmd_download_models(_extra):
         ("PE-Core", cmd_download_pe),
         ("PE-Spatial", cmd_download_pe_spatial),
         ("Anima Tagger vocab", cmd_download_tagger),
+        ("Danbooru classified tags", cmd_download_danbooru_tags),
     ]
     failed: list[str] = []
     for name, fn in components:

--- a/scripts/tasks/downloads.py
+++ b/scripts/tasks/downloads.py
@@ -137,7 +137,8 @@ def cmd_download_danbooru_tags(_extra):
                 tmp.unlink()
             print(f"  ✗ failed: {last_error}")
     raise SystemExit(
-        "failed to download danbooru_tags_classified.csv from sorryhyun/anima_lora"
+        "failed to download danbooru_tags_classified.csv from "
+        "Localsmile/danbooru_KR_wiki_tag_search"
     )
 
 

--- a/scripts/tasks/downloads.py
+++ b/scripts/tasks/downloads.py
@@ -26,8 +26,7 @@ from ._common import ROOT, run
 
 DANBOORU_TAGS_PATH = ROOT / "models" / "danbooru_tags_classified.csv"
 DANBOORU_TAGS_URLS = (
-    "https://github.com/sorryhyun/anima_lora/releases/latest/download/danbooru_tags_classified.csv",
-    "https://raw.githubusercontent.com/sorryhyun/anima_lora/main/models/danbooru_tags_classified.csv",
+    "https://raw.githubusercontent.com/Localsmile/danbooru_KR_wiki_tag_search/main/danbooru_tags_classified.csv",
 )
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -269,6 +269,10 @@ COMMANDS = {
         downloads.cmd_download_tagger,
         "Download Anima Tagger v2 vocab.json (caption-index dependency; not the full model)",
     ),
+    "download-danbooru-tags": (
+        downloads.cmd_download_danbooru_tags,
+        "Download danbooru_tags_classified.csv for caption order correction",
+    ),
     # ── Masking ───────────────────────────────────────────────────────
     "mask": (
         masking.cmd_mask,

--- a/tests/test_caption_correction.py
+++ b/tests/test_caption_correction.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from library.captioning.correction import (
+    CaptionCorrectionOptions,
+    correct_caption,
+    load_tag_knowledge_base,
+)
+
+
+def _csv(path: Path) -> Path:
+    path.write_text(
+        "\n".join(
+            [
+                "name,category,post_count,description",
+                '1girl,0,10,"[인물 > 인원수] count"',
+                'solo,0,10,"[인물 > 인원수] count"',
+                'hatsune_miku,4,10,"[캐릭터 > vocaloid] character"',
+                'vocaloid,3,10,"[작품 > series] copyright"',
+                'sincos,1,10,"[작가 > illustrator] artist"',
+                'best_quality,5,10,"[메타 > 화질] quality"',
+                'long_hair,0,10,"[머리카락 > 머리 길이] general"',
+                'copyright_notice,0,10,"[메타 > 정보_요청] misleading description"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_correct_caption_orders_known_sections_and_preserves_general_order(tmp_path):
+    kb = load_tag_knowledge_base(_csv(tmp_path / "tags.csv"))
+    result = correct_caption(
+        "long hair, vocaloid, @sincos, hatsune miku, 1girl, best quality",
+        kb,
+        options=CaptionCorrectionOptions(insert_no_artist=True),
+    )
+
+    assert result.text == (
+        "best quality, 1girl, hatsune miku, vocaloid, @sincos, long hair"
+    )
+    assert result.changed
+    assert not result.inserted_no_artist
+
+
+def test_correct_caption_inserts_no_artist_at_artist_position(tmp_path):
+    kb = load_tag_knowledge_base(_csv(tmp_path / "tags.csv"))
+    result = correct_caption("long hair, vocaloid, hatsune miku, solo", kb)
+
+    assert result.text == "solo, hatsune miku, vocaloid, @no-artist, long hair"
+    assert result.inserted_no_artist
+
+
+def test_artist_validation_keeps_unknown_at_tag_in_general_tail(tmp_path):
+    kb = load_tag_knowledge_base(_csv(tmp_path / "tags.csv"))
+    result = correct_caption(
+        "@trigger-word, hatsune miku, vocaloid, 1girl",
+        kb,
+        options=CaptionCorrectionOptions(
+            insert_no_artist=True,
+            validate_artist_tags=True,
+        ),
+    )
+
+    assert result.text == (
+        "1girl, hatsune miku, vocaloid, @no-artist, @trigger-word"
+    )
+
+
+def test_artist_validation_does_not_reclassify_at_prefixed_character(tmp_path):
+    kb = load_tag_knowledge_base(_csv(tmp_path / "tags.csv"))
+    result = correct_caption(
+        "@hatsune miku, vocaloid, 1girl",
+        kb,
+        options=CaptionCorrectionOptions(
+            insert_no_artist=True,
+            validate_artist_tags=True,
+        ),
+    )
+
+    assert result.text == "1girl, vocaloid, @no-artist, @hatsune miku"
+
+
+def test_numeric_category_wins_over_description_prefix(tmp_path):
+    kb = load_tag_knowledge_base(_csv(tmp_path / "tags.csv"))
+    result = correct_caption(
+        "copyright notice, hatsune miku, vocaloid, 1girl",
+        kb,
+    )
+
+    assert result.text == (
+        "1girl, hatsune miku, vocaloid, @no-artist, copyright notice"
+    )

--- a/tests/test_caption_correction.py
+++ b/tests/test_caption_correction.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from library.captioning.correction import (
     CaptionCorrectionOptions,
     correct_caption,
+    default_tag_csv_candidates,
+    find_tag_csv,
     load_tag_knowledge_base,
 )
 
@@ -92,3 +94,19 @@ def test_numeric_category_wins_over_description_prefix(tmp_path):
     assert result.text == (
         "1girl, hatsune miku, vocaloid, @no-artist, copyright notice"
     )
+
+
+def test_default_tag_csv_prefers_models_dir_over_env(tmp_path, monkeypatch):
+    root = tmp_path / "repo"
+    model_csv = root / "models" / "danbooru_tags_classified.csv"
+    env_csv = tmp_path / "env.csv"
+    model_csv.parent.mkdir(parents=True)
+    model_csv.write_text("name,category,post_count,description\n", encoding="utf-8")
+    env_csv.write_text("name,category,post_count,description\n", encoding="utf-8")
+    monkeypatch.setenv("ANIMA_DANBOORU_TAGS_CSV", str(env_csv))
+
+    candidates = default_tag_csv_candidates(root)
+
+    assert candidates[0] == model_csv
+    assert root.parent / "danbooru_tags_classified.csv" not in candidates
+    assert find_tag_csv(root) == model_csv

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -5,6 +5,12 @@ from io import BytesIO
 from scripts.tasks import downloads
 
 
+def test_danbooru_tags_download_url_points_to_source_repo():
+    assert downloads.DANBOORU_TAGS_URLS == (
+        "https://raw.githubusercontent.com/Localsmile/danbooru_KR_wiki_tag_search/main/danbooru_tags_classified.csv",
+    )
+
+
 class _FakeResponse:
     def __init__(self, payload: bytes):
         self._payload = payload

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import urllib.error
 from io import BytesIO
+
+import pytest
 
 from scripts.tasks import downloads
 
@@ -60,3 +63,21 @@ def test_download_danbooru_tags_skips_existing_without_force(tmp_path, monkeypat
 
     assert not called
     assert dest.read_text(encoding="utf-8") == "existing"
+
+
+def test_download_danbooru_tags_failure_names_source_repo(tmp_path, monkeypatch):
+    dest = tmp_path / "models" / "danbooru_tags_classified.csv"
+    monkeypatch.setattr(downloads, "DANBOORU_TAGS_PATH", dest)
+    monkeypatch.setattr(downloads, "DANBOORU_TAGS_URLS", ("https://example.test/tags.csv",))
+    monkeypatch.setattr(
+        downloads.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            urllib.error.URLError("nope")
+        ),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        downloads.cmd_download_danbooru_tags([])
+
+    assert "Localsmile/danbooru_KR_wiki_tag_search" in str(exc.value)

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from io import BytesIO
+
+from scripts.tasks import downloads
+
+
+class _FakeResponse:
+    def __init__(self, payload: bytes):
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+    def read(self) -> bytes:
+        return self._payload
+
+
+def test_download_danbooru_tags_writes_models_file(tmp_path, monkeypatch):
+    dest = tmp_path / "models" / "danbooru_tags_classified.csv"
+    monkeypatch.setattr(downloads, "DANBOORU_TAGS_PATH", dest)
+    monkeypatch.setattr(downloads, "DANBOORU_TAGS_URLS", ("https://example.test/tags.csv",))
+    monkeypatch.setattr(
+        downloads.urllib.request,
+        "urlopen",
+        lambda _req, timeout=60: _FakeResponse(
+            b"name,category,post_count,description\n1girl,0,1,test\n"
+        ),
+    )
+
+    downloads.cmd_download_danbooru_tags([])
+
+    assert dest.read_text(encoding="utf-8").startswith("name,category")
+
+
+def test_download_danbooru_tags_skips_existing_without_force(tmp_path, monkeypatch):
+    dest = tmp_path / "models" / "danbooru_tags_classified.csv"
+    dest.parent.mkdir(parents=True)
+    dest.write_text("existing", encoding="utf-8")
+    monkeypatch.setattr(downloads, "DANBOORU_TAGS_PATH", dest)
+    called = False
+
+    def _fail_if_called(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        return _FakeResponse(BytesIO().read())
+
+    monkeypatch.setattr(downloads.urllib.request, "urlopen", _fail_if_called)
+
+    downloads.cmd_download_danbooru_tags([])
+
+    assert not called
+    assert dest.read_text(encoding="utf-8") == "existing"


### PR DESCRIPTION
## 요약

- `danbooru_tags_classified.csv` 기반의 캡션 순서 교정 코어를 추가했습니다.
- 데이터셋 뷰어 캡션 영역에 `Correct order` 버튼을 추가했습니다.
- 현재 캡션 교정과 현재 목록 전체 교정을 지원합니다.
- 작가 태그가 없는 경우 `@no-artist`를 삽입하는 옵션을 설정에 추가했습니다.
- 모델 다운로드 창에서 Danbooru 태그 DB를 받을 수 있게 했습니다.

## 동작

- CSV의 `category` 값을 우선 사용합니다.
  - `0`: general
  - `1`: artist
  - `3`: copyright
  - `4`: character
  - `5`: meta
- `solo`, `1girl`, `multiple girls` 같은 ANIMA 인원수/인물 타입 태그는 count 영역으로 이동합니다.
- 정렬 순서는 `meta/year/rating -> count/person -> character -> copyright -> artist -> general`입니다.
- general 태그 내부 순서는 유지합니다.
- `@no-artist`는 작가 위치에 삽입되어 캡션 셔플 경계로 사용할 수 있습니다.

## 데이터 파일

`danbooru_tags_classified.csv`는 커밋하지 않고 `models/danbooru_tags_classified.csv`에 저장되는 외부 데이터로 사용합니다.

GUI는 다음 순서로 파일을 찾습니다.

- `models/danbooru_tags_classified.csv`
- `ANIMA_DANBOORU_TAGS_CSV` 환경변수

모델 다운로드 창의 `Danbooru tag DB` 항목 또는 `Download all`을 통해 받을 수 있습니다. 다운로드 원본은 `Localsmile/danbooru_KR_wiki_tag_search`의 `danbooru_tags_classified.csv`입니다.

## 검증

- `uv run ruff check library\captioning\correction.py scripts\tasks\downloads.py tasks.py gui\system_dialog.py gui\_paths.py gui\app.py gui\tabs\image_tab.py gui\i18n\en.py gui\i18n\ko.py gui\i18n\ja.py gui\i18n\cn.py tests\test_caption_correction.py tests\test_downloads.py`
- `uv run pytest tests\test_caption_correction.py tests\test_downloads.py tests\test_gui_launch_speed.py`