### PR TITLE
Fix duplicate caption trigger insertion

### DIFF
--- a/gui/tabs/config_tab.py
+++ b/gui/tabs/config_tab.py
@@ -1030,12 +1030,17 @@ class ConfigTab(DaemonJobMixin, DirtyTrackingMixin, QWidget):
             env.update(self._preprocess_tab.preprocess_env())
         return env
 
-    def _chain_train_spec(self, variant: str) -> dict[str, str]:
-        return {
+    def _chain_train_spec(
+        self, variant: str, *, config_snapshot: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        spec: dict[str, Any] = {
             "method": variant,
             "preset": self._IMPLICIT_PRESET,
             "methods_subdir": "gui-methods",
         }
+        if config_snapshot is not None:
+            spec["config_snapshot"] = config_snapshot
+        return spec
 
     @staticmethod
     def _normalize_path_scope(scope: Any) -> str | None:
@@ -1147,6 +1152,18 @@ class ConfigTab(DaemonJobMixin, DirtyTrackingMixin, QWidget):
 
         return _clean(snapshot)
 
+    def _preprocess_config_snapshot(self, variant: str) -> dict[str, Any]:
+        """Config snapshot for the queued preprocess command.
+
+        Training snapshots intentionally strip preprocess-only keys, including
+        source_image_dir. Preprocess still needs the scoped source path, so use
+        the Preprocess tab's own snapshot when available.
+        """
+        if self._preprocess_tab is not None:
+            return self._preprocess_tab.preprocess_config_snapshot()
+        merged, _ = merged_gui_variant_preset(variant, self._IMPLICIT_PRESET)
+        return self._gui_scoped_paths(copy.deepcopy(merged))
+
     def _launch_preprocess(self, variant: str) -> None:
         """Submit the auto-chain preprocess step to the daemon (Phase 2).
 
@@ -1192,7 +1209,12 @@ class ConfigTab(DaemonJobMixin, DirtyTrackingMixin, QWidget):
         # succeeds — the chain then completes even if the GUI closes mid-cache.
         # The spec also tags this command job as *this tab's* preprocess, so
         # ConfigTab re-claims it on reopen and the PreprocessingTab leaves it be.
-        chain_train = self._chain_train_spec(variant) if chain_after else None
+        train_snapshot = self._queue_config_snapshot(variant)
+        chain_train = (
+            self._chain_train_spec(variant, config_snapshot=train_snapshot)
+            if chain_after
+            else None
+        )
 
         def _on_fail():
             self._chain_train_after_preprocess = False
@@ -1204,7 +1226,7 @@ class ConfigTab(DaemonJobMixin, DirtyTrackingMixin, QWidget):
                 argv=["tasks.py", "preprocess"],
                 extra_env=self._preprocess_env(variant),
                 chain_train=chain_train,
-                config_snapshot=self._queue_config_snapshot(variant),
+                config_snapshot=self._preprocess_config_snapshot(variant),
                 start=True,  # main Train auto-chain: run now
             ),
             on_fail=_on_fail,
@@ -1347,13 +1369,21 @@ class ConfigTab(DaemonJobMixin, DirtyTrackingMixin, QWidget):
         queued_key = (
             "queue_added_preprocess" if train_after else "queue_added_preprocess_only"
         )
+        train_snapshot = self._queue_config_snapshot(variant, merged)
+        preprocess_snapshot = self._preprocess_config_snapshot(variant)
+        chain_train = (
+            self._chain_train_spec(variant, config_snapshot=train_snapshot)
+            if train_after
+            else None
+        )
+
         job_id = self._submit_job(
             lambda: gui_daemon.submit_command(
                 label="preprocess",
                 argv=["tasks.py", "preprocess"],
                 extra_env=self._preprocess_env(variant),
-                chain_train=self._chain_train_spec(variant) if train_after else None,
-                config_snapshot=self._queue_config_snapshot(variant, merged),
+                chain_train=chain_train,
+                config_snapshot=preprocess_snapshot,
                 start=False,  # queue dropdown: add to queue, don't start now
             )
         )

--- a/library/captioning/correction.py
+++ b/library/captioning/correction.py
@@ -234,12 +234,12 @@ def correct_caption(
     unknown: list[str] = []
     seen: set[str] = set()
     trigger = options.trigger_word.strip()
-    trigger_present = bool(trigger) and any(
-        tag_key(tag) == tag_key(trigger) for tag in tags
-    )
+    trigger_key = tag_key(trigger) if trigger else ""
 
     for tag in tags:
         key = tag_key(tag)
+        if trigger and key == trigger_key:
+            continue
         if key in seen:
             continue
         seen.add(key)
@@ -249,7 +249,7 @@ def correct_caption(
             kind = "general"
         buckets[kind].append(tag)
 
-    if trigger and not trigger_present:
+    if trigger:
         if options.trigger_at_front:
             buckets["front"].append(trigger)
         else:

--- a/library/captioning/correction.py
+++ b/library/captioning/correction.py
@@ -234,6 +234,9 @@ def correct_caption(
     unknown: list[str] = []
     seen: set[str] = set()
     trigger = options.trigger_word.strip()
+    trigger_present = bool(trigger) and any(
+        tag_key(tag) == tag_key(trigger) for tag in tags
+    )
 
     for tag in tags:
         key = tag_key(tag)
@@ -246,7 +249,7 @@ def correct_caption(
             kind = "general"
         buckets[kind].append(tag)
 
-    if trigger:
+    if trigger and not trigger_present:
         if options.trigger_at_front:
             buckets["front"].append(trigger)
         else:

--- a/tests/test_caption_correction.py
+++ b/tests/test_caption_correction.py
@@ -124,7 +124,7 @@ def test_trigger_preserves_underscores_when_inserted(tmp_path):
     )
 
 
-def test_existing_general_trigger_uses_no_artist_anchor(tmp_path):
+def test_existing_general_trigger_moves_to_artist_slot(tmp_path):
     kb = load_tag_knowledge_base(_csv(tmp_path / "tags.csv"))
     result = correct_caption(
         "long hair, vocaloid, dataset trigger, hatsune miku, 1girl",
@@ -136,15 +136,33 @@ def test_existing_general_trigger_uses_no_artist_anchor(tmp_path):
     )
 
     assert result.text == (
-        "1girl, hatsune miku, vocaloid, @no-artist, long hair, dataset trigger"
+        "1girl, hatsune miku, vocaloid, @dataset_trigger, long hair"
     )
-    assert result.inserted_no_artist
+    assert not result.inserted_no_artist
 
 
 def test_front_trigger_allows_no_artist_when_no_artist_marker(tmp_path):
     kb = load_tag_knowledge_base(_csv(tmp_path / "tags.csv"))
     result = correct_caption(
         "long hair, vocaloid, hatsune miku, 1girl",
+        kb,
+        options=CaptionCorrectionOptions(
+            insert_no_artist=True,
+            trigger_word="@dataset-trigger",
+            trigger_at_front=True,
+        ),
+    )
+
+    assert result.text == (
+        "@dataset-trigger, 1girl, hatsune miku, vocaloid, @no-artist, long hair"
+    )
+    assert result.inserted_no_artist
+
+
+def test_existing_front_trigger_moves_to_front_and_allows_no_artist(tmp_path):
+    kb = load_tag_knowledge_base(_csv(tmp_path / "tags.csv"))
+    result = correct_caption(
+        "long hair, vocaloid, @dataset-trigger, hatsune miku, 1girl",
         kb,
         options=CaptionCorrectionOptions(
             insert_no_artist=True,

--- a/tests/test_caption_correction.py
+++ b/tests/test_caption_correction.py
@@ -91,7 +91,7 @@ def test_trigger_defaults_to_artist_slot_and_suppresses_no_artist(tmp_path):
     assert not result.inserted_no_artist
 
 
-def test_existing_trigger_is_not_removed_by_trigger_insertion(tmp_path):
+def test_existing_artist_trigger_is_not_duplicated(tmp_path):
     kb = load_tag_knowledge_base(_csv(tmp_path / "tags.csv"))
     result = correct_caption(
         "long hair, vocaloid, @dataset-trigger, hatsune miku, 1girl",
@@ -103,14 +103,15 @@ def test_existing_trigger_is_not_removed_by_trigger_insertion(tmp_path):
     )
 
     assert result.text == (
-        "1girl, hatsune miku, vocaloid, @dataset-trigger, @dataset-trigger, long hair"
+        "1girl, hatsune miku, vocaloid, @dataset-trigger, long hair"
     )
+    assert not result.inserted_no_artist
 
 
-def test_trigger_preserves_underscores_in_output(tmp_path):
+def test_trigger_preserves_underscores_when_inserted(tmp_path):
     kb = load_tag_knowledge_base(_csv(tmp_path / "tags.csv"))
     result = correct_caption(
-        "long hair, vocaloid, @dataset trigger, hatsune miku, 1girl",
+        "long hair, vocaloid, hatsune miku, 1girl",
         kb,
         options=CaptionCorrectionOptions(
             insert_no_artist=True,
@@ -119,11 +120,11 @@ def test_trigger_preserves_underscores_in_output(tmp_path):
     )
 
     assert result.text == (
-        "1girl, hatsune miku, vocaloid, @dataset_trigger, @dataset trigger, long hair"
+        "1girl, hatsune miku, vocaloid, @dataset_trigger, long hair"
     )
 
 
-def test_artist_trigger_does_not_remove_same_named_general_tag(tmp_path):
+def test_existing_general_trigger_uses_no_artist_anchor(tmp_path):
     kb = load_tag_knowledge_base(_csv(tmp_path / "tags.csv"))
     result = correct_caption(
         "long hair, vocaloid, dataset trigger, hatsune miku, 1girl",
@@ -135,8 +136,9 @@ def test_artist_trigger_does_not_remove_same_named_general_tag(tmp_path):
     )
 
     assert result.text == (
-        "1girl, hatsune miku, vocaloid, @dataset_trigger, long hair, dataset trigger"
+        "1girl, hatsune miku, vocaloid, @no-artist, long hair, dataset trigger"
     )
+    assert result.inserted_no_artist
 
 
 def test_front_trigger_allows_no_artist_when_no_artist_marker(tmp_path):

--- a/tests/test_gui_snapshot_preprocess_keys.py
+++ b/tests/test_gui_snapshot_preprocess_keys.py
@@ -17,6 +17,26 @@ The snapshot builder now strips the whole preprocess-only key set.
 from __future__ import annotations
 
 import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+
+@contextmanager
+def _temporary_custom_variant(name: str) -> Iterator[tuple[str, object]]:
+    from gui import variant_path
+
+    variant = f"custom/{name}"
+    path = variant_path(variant)
+    old_text = path.read_text(encoding="utf-8") if path.exists() else None
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text('[variant]\nfamily = "lora"\n', encoding="utf-8")
+    try:
+        yield variant, path
+    finally:
+        if old_text is None:
+            path.unlink(missing_ok=True)
+        else:
+            path.write_text(old_text, encoding="utf-8")
 
 
 def _make_config_tab():
@@ -29,6 +49,20 @@ def _make_config_tab():
     app = QApplication.instance() or QApplication([])
     assert app is not None
     return ConfigTab()
+
+
+def _make_config_and_preprocess_tabs():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+    from PySide6.QtWidgets import QApplication
+
+    from gui.tabs.config_tab import ConfigTab
+    from gui.tabs.preprocess_tab import PreprocessingTab
+
+    app = QApplication.instance() or QApplication([])
+    assert app is not None
+    preprocess_tab = PreprocessingTab()
+    return ConfigTab(preprocess_tab=preprocess_tab), preprocess_tab
 
 
 def test_snapshot_drops_preprocess_only_keys():
@@ -51,3 +85,36 @@ def test_snapshot_drops_preprocess_only_keys():
     # Sanity: a genuine training knob still survives (caption_dropout_rate is a
     # legit train arg — it's TE-cache-compatible via cache_supports_dropout).
     assert "caption_dropout_rate" in snapshot
+
+
+def test_preprocess_queue_snapshot_keeps_scoped_source_separate_from_train_snapshot():
+    from gui.tabs.preprocess_tab import _GUI_PREPROCESS_KEYS
+
+    config_tab = None
+    preprocess_tab = None
+    with _temporary_custom_variant("__pytest_queue_scope__") as (variant, _path):
+        config_tab, preprocess_tab = _make_config_and_preprocess_tabs()
+        try:
+            preprocess_tab.set_variant(variant, method="lora")
+            preprocess_tab.source_dir_edit.setText("image_dataset")
+            preprocess_tab.path_scope_edit.setText("scope1")
+
+            preprocess_snapshot = config_tab._preprocess_config_snapshot(variant)
+            train_snapshot = config_tab._queue_config_snapshot(variant)
+            chain_spec = config_tab._chain_train_spec(
+                variant, config_snapshot=train_snapshot
+            )
+        finally:
+            if config_tab is not None:
+                config_tab.deleteLater()
+            if preprocess_tab is not None:
+                preprocess_tab.deleteLater()
+
+    assert preprocess_snapshot["source_image_dir"] == "image_dataset/scope1"
+    assert preprocess_snapshot["resized_image_dir"] == "post_image_dataset/resized/scope1"
+    assert preprocess_snapshot["lora_cache_dir"] == "post_image_dataset/lora/scope1"
+
+    assert "source_image_dir" not in train_snapshot
+    leaked = _GUI_PREPROCESS_KEYS & train_snapshot.keys()
+    assert not leaked, f"preprocess-only keys leaked into training snapshot: {leaked}"
+    assert chain_spec["config_snapshot"] == train_snapshot


### PR DESCRIPTION
## Summary

전처리 캡션 교정과 GUI 전처리+학습 큐 경로 snapshot 관련 버그를 수정합니다.

## Fixes two bugs

1. Existing trigger words could be duplicated or left in the wrong slot.

   When `caption_trigger_word` was already present in the source caption, correction could either insert the same trigger again or skip insertion without moving the existing tag. This broke the intended `caption_trigger_at_front=true` behavior: the trigger did not move to the front, and because it still occupied the artist bucket, `@no-artist` was not inserted as the shuffle anchor.

2. GUI `Preprocess + Train` queue could ignore `path_scope` during preprocess.

   The Config tab queued preprocess using the training config snapshot. That snapshot intentionally strips preprocess-only fields such as `source_image_dir`, so the queued preprocess command could fall back to the unscoped source root instead of reading `image_dataset/<path_scope>`. The follow-up train job still needs the stripped training snapshot, so this PR separates the preprocess snapshot from the chained train snapshot.

## Changes

- `caption_trigger_word`가 원본 캡션에 이미 있을 때 matching trigger tag를 먼저 제거한 뒤 설정된 위치에 한 번만 재배치
- `caption_trigger_at_front=false`: 트리거를 artist 위치에 두고 기존 작가 태그보다 앞에 배치
- `caption_trigger_at_front=true`: 트리거를 caption 맨 앞에 두고, artist bucket이 비어 있으면 `@no-artist`를 삽입해 shuffle 고정점 유지
- 트리거 워드의 underscore는 기존 리뷰 요청대로 normalize하지 않고 보존
- 학습 설정 탭의 `전처리 + 학습` 큐에서 preprocess command snapshot과 chained train snapshot을 분리
  - preprocess job: scoped `source_image_dir`와 preprocess-only 옵션을 유지
  - chained train job: preprocess-only keys를 제거한 학습용 snapshot을 별도로 사용

## Notes

`anima_smart_shuffle_caption()`은 중복 artist 태그를 제거하지 않고, 연속된 `@...` 구간을 prefix로 보호합니다. 그래서 중복 제거와 trigger 재배치는 shuffle 단계가 아니라 caption correction 단계에서 처리합니다.

예상 동작 예:

```toml
caption_correct_order = true
caption_insert_no_artist = true
caption_trigger_word = "@km1m1"
caption_trigger_at_front = true
```

원본 caption 안에 `@km1m1`이 이미 있으면 중복하지 않고 맨 앞으로 이동하며, 별도 artist tag가 없으면 artist 위치에 `@no-artist`가 추가됩니다.

GUI queue path에서는 `path_scope=scope1`일 때 preprocess job이 `image_dataset/scope1`을 읽고, chained train job은 같은 scoped cache/output 경로를 쓰되 preprocess-only source/filter keys는 받지 않습니다.

## Validation

- `uv run pytest tests/test_gui_snapshot_preprocess_keys.py tests/test_gui_preprocess_tab.py tests/test_preprocess_tasks.py tests/test_caption_correction.py tests/test_caption_shuffle.py`
- `uv run ruff check gui/tabs/config_tab.py tests/test_gui_snapshot_preprocess_keys.py`
- `uv run python -m py_compile gui\tabs\config_tab.py tests\test_gui_snapshot_preprocess_keys.py`
- `git diff --check`