### PR TITLE
Add weight-space interference analysis to LoRA merge

### DIFF
--- a/gui/i18n/cn.py
+++ b/gui/i18n/cn.py
@@ -623,6 +623,8 @@ STRINGS: dict[str, str] = {
     "merge_normalize": "归一化：",
     "merge_normalize_tip": "将合并后的增量重新缩放到单个 LoRA 的量级。'global'（默认）使全局 RMS 与平均单 LoRA 范数匹配；'per_module' 逐模块匹配但会重新加权各层；'off' 为原始精确拼接和（可能过度驱动 DiT）。",
     "merge_lora_button": "合并 LoRA",
+    "merge_analyze_button": "分析干涉",
+    "merge_analyze_tip": "试运行：报告所选 LoRA 在权重空间中的相互干涉（逐对、逐层的相长增强还是相消抵消），不写出合并文件。",
     "merge_lora_out_placeholder": "（自动：<首个 LoRA>_merged<N>.safetensors）",
     "browse": "浏览……",
     # Multi-scale target_res tiers

--- a/gui/i18n/en.py
+++ b/gui/i18n/en.py
@@ -703,6 +703,8 @@ STRINGS: dict[str, str] = {
     "merge_normalize": "Normalize:",
     "merge_normalize_tip": "Rescale the merged delta to single-LoRA magnitude. 'global' (default) matches the global RMS to the average single-LoRA norm; 'per_module' matches each module but reweights layers; 'off' = raw exact-concat sum (can overdrive the DiT).",
     "merge_lora_button": "Merge LoRAs",
+    "merge_analyze_button": "Analyze interference",
+    "merge_analyze_tip": "Dry-run: report how the selected LoRAs interfere in weight space (constructive reinforce vs destructive cancel, per pair and per layer) without writing a merged file.",
     "merge_lora_out_placeholder": "(auto: <first-lora>_merged<N>.safetensors)",
     "browse": "Browse…",
     # Multi-scale target_res tiers

--- a/gui/i18n/ja.py
+++ b/gui/i18n/ja.py
@@ -645,6 +645,8 @@ STRINGS: dict[str, str] = {
     "merge_normalize": "正規化:",
     "merge_normalize_tip": "マージしたデルタを単一 LoRA の大きさに再スケーリングします。'global'（既定）はグローバル RMS を平均単一 LoRA ノルムに合わせ、'per_module' はモジュールごとに合わせますがレイヤー重みが変わり、'off' は生の厳密連結和（DiT を過剰駆動する可能性があります）です。",
     "merge_lora_button": "LoRA をマージ",
+    "merge_analyze_button": "干渉を分析",
+    "merge_analyze_tip": "ドライラン: 選択した LoRA が重み空間でどう干渉するか（ペアごと・層ごとの強め合い対打ち消し合い）を、マージファイルを書き出さずにレポートします。",
     "merge_lora_out_placeholder": "（自動: <最初の LoRA>_merged<N>.safetensors）",
     "browse": "参照…",
     # Multi-scale target_res tiers

--- a/gui/i18n/ko.py
+++ b/gui/i18n/ko.py
@@ -685,6 +685,8 @@ STRINGS: dict[str, str] = {
     "merge_normalize": "정규화:",
     "merge_normalize_tip": "병합된 델타를 단일 LoRA 크기로 재조정합니다. 'global'(기본값)은 전역 RMS를 평균 단일 LoRA 노름에 맞추고, 'per_module'은 모듈별로 맞추지만 레이어 가중치가 바뀌며, 'off'는 원시 정확 연결 합계(DiT를 과도하게 구동할 수 있음)입니다.",
     "merge_lora_button": "LoRA 병합",
+    "merge_analyze_button": "간섭 분석",
+    "merge_analyze_tip": "드라이런: 선택한 LoRA들이 가중치 공간에서 어떻게 간섭하는지(쌍별·레이어별로 보강 대 상쇄) 병합 파일을 쓰지 않고 보고합니다.",
     "merge_lora_out_placeholder": "(자동: <첫 LoRA>_merged<N>.safetensors)",
     "browse": "찾아보기…",
     # Multi-scale target_res tiers

--- a/gui/tabs/merge_tab.py
+++ b/gui/tabs/merge_tab.py
@@ -314,6 +314,14 @@ class MergeTab(LazyTabMixin, QWidget):
         )
         bar.addWidget(self.merge_btn)
 
+        # LoRA-mode only: dry-run weight-space interference report (no file written).
+        self.analyze_btn = action_button(
+            t("merge_analyze_button"), variant="info", on_click=self._start_analyze
+        )
+        self.analyze_btn.setToolTip(t("merge_analyze_tip"))
+        self.analyze_btn.setVisible(False)
+        bar.addWidget(self.analyze_btn)
+
         self.stop_btn = QPushButton(t("stop"))
         self.stop_btn.setEnabled(False)
         self.stop_btn.clicked.connect(self._stop_merge)
@@ -483,6 +491,7 @@ class MergeTab(LazyTabMixin, QWidget):
             else QAbstractItemView.SingleSelection
         )
         self.merge_btn.setText(t("merge_lora_button") if lora else t("merge_button"))
+        self.analyze_btn.setVisible(lora)
         if lora:
             self._on_lora_selection()
         else:
@@ -497,9 +506,9 @@ class MergeTab(LazyTabMixin, QWidget):
             "\n".join(f"{i + 1}. {p.name}" for i, p in enumerate(sel))
             or t("merge_lora_need_two")
         )
-        self.merge_btn.setEnabled(
-            self._proc.state() == QProcess.NotRunning and len(sel) >= 2
-        )
+        enabled = self._proc.state() == QProcess.NotRunning and len(sel) >= 2
+        self.merge_btn.setEnabled(enabled)
+        self.analyze_btn.setEnabled(enabled)
 
     def _start_merge(self):
         if self._proc.state() != QProcess.NotRunning:
@@ -562,6 +571,26 @@ class MergeTab(LazyTabMixin, QWidget):
             args += ["--weights", weights]
         self._launch(args)
 
+    def _start_analyze(self):
+        """Dry-run interference report for the selected LoRAs (writes nothing)."""
+        if self._proc.state() != QProcess.NotRunning:
+            return
+        sel = self._selected_loras()
+        if len(sel) < 2:
+            QMessageBox.warning(self, t("error"), t("merge_lora_need_two"))
+            return
+        args = ["scripts/merge_loras.py", *[str(p) for p in sel], "--analyze"]
+        weights = self.weights_edit.text().strip()
+        if weights:
+            n = len(weights.split(","))
+            if n != len(sel):
+                QMessageBox.warning(
+                    self, t("error"), t("merge_weights_mismatch", n=n, m=len(sel))
+                )
+                return
+            args += ["--weights", weights]
+        self._launch(args)
+
     def _launch(self, args: list[str]):
         import sys as _sys
 
@@ -569,6 +598,7 @@ class MergeTab(LazyTabMixin, QWidget):
         self._log(f"> {_sys.executable} {' '.join(args)}\n")
 
         self.merge_btn.setEnabled(False)
+        self.analyze_btn.setEnabled(False)
         apply_variant(self.merge_btn, "busy")
         self.merge_btn.setText(self.merge_btn.text() + " ...")
         self.stop_btn.setEnabled(True)

--- a/library/anima/merge_analysis.py
+++ b/library/anima/merge_analysis.py
@@ -1,0 +1,217 @@
+"""Weight-space interference analysis for multi-LoRA merges.
+
+When ``scripts/merge_loras.py`` fuses N adapters it sums their weight-deltas
+``ΔW_i = (α_i/r_i)·up_i @ down_i``.  The energy of that sum is **not** just the
+sum of energies — it carries pairwise cross-terms::
+
+    ‖Σ_i ΔW_i‖²_F = Σ_i ‖ΔW_i‖²_F  +  2·Σ_{i<j} ⟨ΔW_i, ΔW_j⟩_F
+                                       └──────── interference ────────┘
+
+- ``⟨ΔW_i, ΔW_j⟩ > 0`` → **constructive**: the two LoRAs push the same
+  direction in weight space (reinforcing — risk of overdrive into high-freq
+  noise once summed).
+- ``< 0`` → **destructive**: they partially cancel — one LoRA erodes the
+  other's learned effect.
+- ``≈ 0`` → orthogonal/independent — the ``--normalize global`` √N-quadrature
+  assumption holds.
+
+The merge script already derives a normalization scale *assuming* orthogonality
+but never reports the actual interference, so two stylistically-opposed LoRAs
+get silently cancelled with no diagnostic.  This module measures it exactly and
+cheaply via the Gram-trace identity — no ``out×in`` ΔW is ever materialized
+(mirrors ``merge_loras.fro2``)::
+
+    ⟨ΔW_i, ΔW_j⟩_F = Σ( (up_iᵀ up_j) ⊙ (down_i down_jᵀ) )
+
+The per-LoRA scale ``(α/r)·w`` is folded into the up factor before measuring, so
+the energy-weighted aggregate reflects what the merge actually writes (pairwise
+*cosine* is scale-invariant, but the per-module weighting of the global cosine
+is not).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from itertools import combinations
+
+import torch
+
+# Loaded-LoRA tuple as returned by ``scripts/merge_loras.load_lora``:
+# (downs, ups, alphas) keyed by module stem.
+LoadedLoRA = tuple[dict[str, torch.Tensor], dict[str, torch.Tensor], dict[str, float]]
+
+_EPS = 1e-12
+
+
+def _scaled_up(up: torch.Tensor, down: torch.Tensor, alpha: float | None, w: float):
+    """``up`` with ``(α/r)·w`` folded in — matches ``merge_loras`` line ``ups_cat``."""
+    r = down.shape[0]
+    s = (alpha if alpha is not None else float(r)) / r
+    return up * (s * w)
+
+
+def _gram_inner(up_i, down_i, up_j, down_j) -> float:
+    """⟨up_i@down_i, up_j@down_j⟩_F via the Gram-trace identity (no out×in)."""
+    return ((up_i.T @ up_j) * (down_i @ down_j.T)).sum().item()
+
+
+@dataclass
+class InterferenceReport:
+    """Pairwise + aggregate weight-space interference for a multi-LoRA merge."""
+
+    names: list[str]
+    weights: list[float]
+    n_inputs: int
+    n_modules: int  # union of module stems
+    n_shared_modules: int  # stems present in ≥2 inputs (interference only defined here)
+    # Global energy-weighted cosine per input pair, keyed by (i, j) with i < j.
+    pair_cosine: dict[tuple[int, int], float]
+    # ‖Σ ΔW‖² / Σ‖ΔW_i‖² over the whole weight space. 1 = orthogonal,
+    # >1 = net constructive, <1 = net destructive.
+    overall_energy_ratio: float
+    # Per-module energy-excess index (2·Σ_{i<j}⟨⟩ / Σ‖·‖²): <0 destructive layer.
+    module_index: dict[str, float] = field(default_factory=dict)
+
+    @property
+    def worst_pair(self) -> tuple[tuple[int, int], float] | None:
+        """The input pair with the most negative (destructive) cosine, if any."""
+        if not self.pair_cosine:
+            return None
+        return min(self.pair_cosine.items(), key=lambda kv: kv[1])
+
+    def _verdict(self, ratio: float) -> str:
+        if ratio > 1.05:
+            return "constructive"
+        if ratio < 0.95:
+            return "destructive"
+        return "orthogonal"
+
+    def summary_line(self) -> str:
+        v = self._verdict(self.overall_energy_ratio)
+        worst = self.worst_pair
+        tail = ""
+        if worst is not None:
+            (i, j), c = worst
+            tail = f" — most opposed: {self.names[i]}↔{self.names[j]} cos={c:+.3f}"
+        return (
+            f"interference: energy ratio {self.overall_energy_ratio:.3f} ({v}), "
+            f"{self.n_shared_modules}/{self.n_modules} shared modules{tail}"
+        )
+
+
+def analyze(
+    loaded: list[LoadedLoRA],
+    names: list[str],
+    weights: list[float] | None = None,
+) -> InterferenceReport:
+    """Compute weight-space interference across ``loaded`` LoRAs.
+
+    ``loaded`` / ``names`` / ``weights`` are parallel lists (one entry per input
+    adapter); ``loaded[k]`` is the ``(downs, ups, alphas)`` tuple from
+    ``merge_loras.load_lora``. ``weights`` defaults to all-1.0.
+    """
+    n = len(loaded)
+    if n < 2:
+        raise ValueError("interference analysis needs at least 2 LoRAs")
+    if weights is None:
+        weights = [1.0] * n
+
+    # Pre-scale every module's up factor by (α/r)·w once.
+    scaled: list[dict[str, tuple[torch.Tensor, torch.Tensor]]] = []
+    for (downs, ups, alphas), w in zip(loaded, weights):
+        per: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
+        for stem, down in downs.items():
+            if stem not in ups:
+                continue
+            per[stem] = (_scaled_up(ups[stem], down, alphas.get(stem), w), down)
+        scaled.append(per)
+
+    stems = sorted({s for per in scaled for s in per})
+
+    # Global accumulators: per-input energy N_i, per-pair inner product S_ij.
+    norm_sq = [0.0] * n
+    inner = {pair: 0.0 for pair in combinations(range(n), 2)}
+    module_index: dict[str, float] = {}
+    n_shared = 0
+
+    for stem in stems:
+        present = [k for k in range(n) if stem in scaled[k]]
+        # Per-module energy bookkeeping for the local interference index.
+        m_norm = {}
+        for k in present:
+            up_k, down_k = scaled[k][stem]
+            nrm = _gram_inner(up_k, down_k, up_k, down_k)
+            m_norm[k] = nrm
+            norm_sq[k] += nrm
+        m_cross = 0.0
+        for i, j in combinations(present, 2):
+            up_i, down_i = scaled[i][stem]
+            up_j, down_j = scaled[j][stem]
+            s = _gram_inner(up_i, down_i, up_j, down_j)
+            inner[(i, j)] += s
+            m_cross += s
+        if len(present) >= 2:
+            n_shared += 1
+            denom = sum(m_norm.values()) + _EPS
+            module_index[stem] = 2.0 * m_cross / denom
+
+    pair_cosine = {}
+    for (i, j), s in inner.items():
+        denom = (norm_sq[i] * norm_sq[j]) ** 0.5 + _EPS
+        pair_cosine[(i, j)] = s / denom
+
+    total_norm = sum(norm_sq)
+    total_cross = sum(inner.values())
+    overall_energy_ratio = (total_norm + 2.0 * total_cross) / (total_norm + _EPS)
+
+    return InterferenceReport(
+        names=list(names),
+        weights=list(weights),
+        n_inputs=n,
+        n_modules=len(stems),
+        n_shared_modules=n_shared,
+        pair_cosine=pair_cosine,
+        overall_energy_ratio=overall_energy_ratio,
+        module_index=module_index,
+    )
+
+
+def format_report(report: InterferenceReport, *, top_modules: int = 8) -> str:
+    """Human-readable multi-line interference report for CLI / GUI log output."""
+    lines: list[str] = []
+    lines.append("=" * 64)
+    lines.append("LoRA merge — weight-space interference analysis")
+    lines.append("=" * 64)
+    for k, (nm, w) in enumerate(zip(report.names, report.weights)):
+        lines.append(f"  [{k}] {nm}  (weight {w:g})")
+    lines.append("")
+    lines.append(report.summary_line())
+    lines.append(
+        "  energy ratio = ‖Σ ΔW‖² / Σ‖ΔW_i‖²  "
+        "(1.0 = orthogonal, >1 reinforce, <1 cancel)"
+    )
+    lines.append("")
+
+    lines.append("Pairwise interference (global energy-weighted cosine):")
+    for (i, j), c in sorted(report.pair_cosine.items()):
+        if c > 0.05:
+            tag = "constructive"
+        elif c < -0.05:
+            tag = "destructive"
+        else:
+            tag = "orthogonal"
+        lines.append(f"  {report.names[i]} ↔ {report.names[j]}: {c:+.3f}  ({tag})")
+    lines.append("")
+
+    if report.module_index:
+        worst = sorted(report.module_index.items(), key=lambda kv: kv[1])[:top_modules]
+        lines.append(f"Most destructive modules (of {report.n_shared_modules} shared):")
+        any_neg = False
+        for stem, idx in worst:
+            if idx < 0:
+                any_neg = True
+                lines.append(f"  {idx:+.3f}  {stem}")
+        if not any_neg:
+            lines.append("  (none — no module has net cancellation)")
+    lines.append("=" * 64)
+    return "\n".join(lines)

--- a/scripts/merge_loras.py
+++ b/scripts/merge_loras.py
@@ -43,6 +43,7 @@ import torch
 from safetensors import safe_open
 from safetensors.torch import save_file
 
+from library.anima import merge_analysis
 from library.log import setup_logging
 
 setup_logging()
@@ -80,6 +81,13 @@ def main() -> int:
     )
     ap.add_argument("--dtype", choices=["bf16", "fp16", "fp32"], default="bf16")
     ap.add_argument(
+        "--analyze",
+        action="store_true",
+        help="Dry-run: report weight-space interference between the inputs "
+        "(pairwise constructive/destructive cosine + worst layers) and exit "
+        "WITHOUT writing a merged file.",
+    )
+    ap.add_argument(
         "--normalize",
         choices=["off", "global", "per_module"],
         default="global",
@@ -110,6 +118,16 @@ def main() -> int:
 
     loaded = [load_lora(p) for p in args.loras]
     names = [Path(p).stem for p in args.loras]
+
+    # Weight-space interference: how much the inputs reinforce vs cancel once
+    # summed. A one-line summary always; the full report (and an early exit) on
+    # --analyze. Cheap — same Gram-trace identity as fro2, no out×in ΔW.
+    report = merge_analysis.analyze(loaded, names, weights)
+    if args.analyze:
+        print(merge_analysis.format_report(report))
+        return 0
+    logger.info(report.summary_line())
+
     logger.info("merging %d LoRAs: %s  weights=%s", len(names), names, weights)
 
     def fro2(up: torch.Tensor, down: torch.Tensor) -> torch.Tensor:

--- a/tests/test_merge_interference.py
+++ b/tests/test_merge_interference.py
@@ -1,0 +1,75 @@
+"""Invariant tests for LoRA merge weight-space interference analysis.
+
+Covers the three reference regimes of ``library.anima.merge_analysis.analyze``:
+identical deltas (cos +1, ratio →N²/N), negated deltas (cos -1, cancellation),
+and orthogonal deltas (cos 0, ratio 1). Also checks the Gram-trace inner product
+matches a dense ``⟨ΔW_i, ΔW_j⟩_F`` and that ``--weights`` scaling is respected.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from library.anima import merge_analysis as ma
+
+
+def _lora(down: torch.Tensor, up: torch.Tensor, stem: str = "blk.0.attn"):
+    """Build a one-module loaded-LoRA tuple with alpha == rank (scale 1)."""
+    r = down.shape[0]
+    return ({stem: down}, {stem: up}, {stem: float(r)})
+
+
+def _dense_inner(up_i, down_i, up_j, down_j) -> float:
+    return torch.tensordot(up_i @ down_i, up_j @ down_j, dims=2).item()
+
+
+def test_gram_inner_matches_dense():
+    torch.manual_seed(0)
+    up_i, down_i = torch.randn(8, 4), torch.randn(4, 6)
+    up_j, down_j = torch.randn(8, 4), torch.randn(4, 6)
+    got = ma._gram_inner(up_i, down_i, up_j, down_j)
+    assert abs(got - _dense_inner(up_i, down_i, up_j, down_j)) < 1e-4
+
+
+def test_identical_loras_constructive():
+    torch.manual_seed(1)
+    down, up = torch.randn(4, 6), torch.randn(8, 4)
+    rep = ma.analyze([_lora(down, up), _lora(down, up)], ["a", "b"])
+    assert rep.pair_cosine[(0, 1)] == 1.0 or abs(rep.pair_cosine[(0, 1)] - 1.0) < 1e-5
+    # Two identical deltas: ‖2ΔW‖² / 2‖ΔW‖² = 4/2 = 2.
+    assert abs(rep.overall_energy_ratio - 2.0) < 1e-4
+    assert rep.n_shared_modules == 1
+
+
+def test_negated_loras_destructive():
+    torch.manual_seed(2)
+    down, up = torch.randn(4, 6), torch.randn(8, 4)
+    rep = ma.analyze([_lora(down, up), _lora(down, -up)], ["a", "b"])
+    assert abs(rep.pair_cosine[(0, 1)] - (-1.0)) < 1e-5
+    # Perfect cancellation: ‖ΔW - ΔW‖² = 0.
+    assert abs(rep.overall_energy_ratio) < 1e-4
+    assert rep.worst_pair[0] == (0, 1)
+
+
+def test_orthogonal_loras_independent():
+    # Disjoint output rows → ⟨ΔW_i, ΔW_j⟩ = 0 regardless of down.
+    down = torch.randn(4, 6)
+    up_a = torch.zeros(8, 4)
+    up_a[:4] = torch.randn(4, 4)
+    up_b = torch.zeros(8, 4)
+    up_b[4:] = torch.randn(4, 4)
+    rep = ma.analyze([_lora(down, up_a), _lora(down, up_b)], ["a", "b"])
+    assert abs(rep.pair_cosine[(0, 1)]) < 1e-5
+    assert abs(rep.overall_energy_ratio - 1.0) < 1e-4
+
+
+def test_weight_scaling_changes_energy_not_cosine():
+    torch.manual_seed(3)
+    down, up = torch.randn(4, 6), torch.randn(8, 4)
+    loaded = [_lora(down, up), _lora(down, -up)]
+    base = ma.analyze(loaded, ["a", "b"])
+    scaled = ma.analyze(loaded, ["a", "b"], weights=[1.0, 0.5])
+    # Cosine is scale-invariant; still anti-aligned.
+    assert abs(scaled.pair_cosine[(0, 1)] - base.pair_cosine[(0, 1)]) < 1e-5
+    # But partial cancellation now leaves residual energy (ratio > 0).
+    assert scaled.overall_energy_ratio > 0.1


### PR DESCRIPTION
When merge_loras.py fuses N adapters it sums their weight-deltas, and the
energy of that sum carries pairwise cross-terms: aligned deltas reinforce
(risk of overdrive), opposed deltas cancel (one LoRA erodes another). The
script previously derived its normalize scale *assuming* orthogonality but
never reported the actual interference, so a destructive merge was silent.

- library/anima/merge_analysis.py: exact, cheap interference via the
  Gram-trace identity (no out×in materialization, mirrors fro2) — pairwise
  energy-weighted cosine, overall energy ratio, per-module index.
- scripts/merge_loras.py: --analyze dry-run prints the full report and exits
  without writing; normal merges now log a one-line interference summary.
- gui/tabs/merge_tab.py: "Analyze interference" button in LoRA-merge mode
  (spawns the script via QProcess, keeping the GUI torch-free per gui/CLAUDE.md).
- i18n strings across en/ko/ja/cn; invariant test for the identical/negated/
  orthogonal regimes plus Gram-vs-dense and weight-scaling checks.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019BnN4W3UmoBNv3EgH5Tpgs