### PR TITLE
Reduce VAE batch size to 2 and auto-fetch Danbooru tags

### DIFF
--- a/scripts/preprocess/cache_latents.py
+++ b/scripts/preprocess/cache_latents.py
@@ -25,7 +25,7 @@ def main() -> None:
         parser,
         cache_noun="latent caches",
         include_batch_size=True,
-        batch_size_default=4,
+        batch_size_default=2,
     )
     parser.add_argument("--vae", type=str, required=True, help="Path to VAE weights")
     parser.add_argument(

--- a/scripts/tasks/preprocess.py
+++ b/scripts/tasks/preprocess.py
@@ -545,7 +545,7 @@ def cmd_preprocess_vae(extra):
             "--vae",
             "models/vae/qwen_image_vae.safetensors",
             "--batch_size",
-            "4",
+            "2",
             "--chunk_size",
             "64",
             "--recursive",
@@ -588,6 +588,32 @@ def _float_or_zero(value: str) -> float:
         return 0.0
 
 
+def _ensure_danbooru_tags() -> None:
+    """Fetch the Danbooru tag KB on demand so caption correction never aborts.
+
+    ``correct_captions.py`` loads ``danbooru_tags_classified.csv`` (the bucket
+    taxonomy) and ``SystemExit``s if it's missing — GUI users reach preprocess
+    without ``make download-danbooru-tags``. Mirror the tagger-vocab auto-fetch
+    (best-effort): catch ``SystemExit``/``OSError`` so a failed download skips
+    rather than aborts; ``correct_captions.py`` still surfaces its own clear
+    error if the file is genuinely unavailable.
+    """
+    from library.captioning.correction import find_tag_csv
+
+    if find_tag_csv(ROOT) is not None:
+        return
+    print("  [preprocess] danbooru tag KB missing; fetching it for caption correction")
+    try:
+        # Base CSV only — that's the file `find_tag_csv` / `correct_captions.py`
+        # need. The English sibling (`download-danbooru-tags`) is a heavier
+        # wiki-join step only the GUI tooltip uses; skip it on the preprocess path.
+        from .downloads import _download_danbooru_base
+
+        _download_danbooru_base([])
+    except (SystemExit, OSError) as e:
+        print(f"  [preprocess] danbooru tag KB auto-download failed: {e}")
+
+
 def cmd_preprocess_captions(extra, caption_config: dict[str, object] | None = None):
     """Write corrected/variant caption sidecars into ``resized/``.
 
@@ -605,6 +631,10 @@ def cmd_preprocess_captions(extra, caption_config: dict[str, object] | None = No
     if not correct and n_variants <= 0:
         print("  [preprocess] caption correction disabled")
         return
+    # correct_captions.py loads the Danbooru tag KB unconditionally (bucket
+    # taxonomy for both correct + variant-only paths) — fetch it on demand so a
+    # GUI preprocess that skipped `make download-danbooru-tags` doesn't abort.
+    _ensure_danbooru_tags()
     pp_args = _resolved_path_pattern_args(extra)
     cmd = [
         PY,
@@ -965,7 +995,7 @@ def cmd_preprocess_config(extra):
                 "--vae",
                 vae_path,
                 "--batch_size",
-                "4",
+                "2",
                 "--chunk_size",
                 "64",
                 "--recursive",


### PR DESCRIPTION
## Summary
This PR reduces the default VAE batch size from 4 to 2 for latent caching and adds automatic on-demand fetching of Danbooru tags during caption preprocessing to prevent aborts when users skip the manual download step.

## Changes

- **VAE batch size reduction**: Lowered `batch_size_default` from 4 to 2 in `cache_latents.py` and updated hardcoded batch size values in `preprocess.py` (both `cmd_preprocess_vae` and `cmd_preprocess_config`). This improves compatibility with lower-VRAM setups.

- **Auto-fetch Danbooru tags**: Added `_ensure_danbooru_tags()` function that:
  - Checks if the Danbooru tag KB (`danbooru_tags_classified.csv`) is already present
  - Automatically downloads it on demand if missing, mirroring the tagger-vocab auto-fetch pattern
  - Gracefully handles download failures (catches `SystemExit`/`OSError`) so preprocessing continues; `correct_captions.py` will still surface its own error if the file is genuinely unavailable
  - Downloads only the base CSV (not the heavier English wiki-join variant used by GUI tooltips)

- **Integration**: Integrated `_ensure_danbooru_tags()` into `cmd_preprocess_captions()` to run before caption correction, ensuring GUI users who skip `make download-danbooru-tags` don't hit an abort.

## Implementation Details

The Danbooru tag KB is now fetched best-effort during preprocessing, matching the existing tagger-vocab auto-download pattern. This prevents the common user friction where GUI preprocessing aborts due to missing caption correction dependencies, while still allowing `correct_captions.py` to surface clear errors if the file is genuinely unavailable after the auto-fetch attempt.

https://claude.ai/code/session_01C4FaE7RLMuimvkyKgrK4A9