### PR TITLE
sr/rsd: align SiD normalization + noise injection with official RSD release

### DIFF
--- a/sr/distill_rsd/DESIGN.md
+++ b/sr/distill_rsd/DESIGN.md
@@ -35,6 +35,31 @@ signal becomes **"1-step student beats the v2 teacher perceptually"** (the paper
 central claim: RSD LPIPS 0.273 < teacher 0.360; MUSIQ 65.9 > 59.9 on RealSR) rather
 than hitting the exact published digits.
 
+## Official release reconciliation (2026-07-01)
+
+The RSD authors released code (ICML 2026). It ships the **orchestration only** —
+`trainer.py` / `sampler.py` / `main_distill.py` / config / data pipeline — and **omits the
+entire `models/` package** (the DMD-core `training_student_losses` / `training_fake_losses`,
+`UNetModelSwinGanWrapper`, and the noise-consuming UNet `forward`). SinSR (the base repo)
+supplies only `UNetModelSwin` + `create_gaussian_diffusion`, not those RSD additions — so the
+generator-gradient form and exact node timesteps remain unverifiable from public code. What
+*is* observable (config + `trainer.py`) confirmed most of this reconstruction; two mechanisms
+diverged and are now selectable (both default to backward-compatible behavior except SiD):
+
+- **SiD normalization** (`train.py --sid_denom`): official (`trainer.py:1836`) divides the
+  per-sample DMD loss by `|teacher_x0 − student_x0| + 1e-8`. Our original divided by
+  `|z_t − teacher_x0|` floored 0.05. Default is now `student` (official); `input` keeps the old form.
+- **Noise injection** (`--noise_mode`): official (`sampler.py:79`) widens the first input conv
+  by `noise_channels=1` and **concats** eps; ours adds a separate 3-ch `noise_proj` after block0.
+  Default stays `add` (existing checkpoints load); `concat` matches the release but changes the
+  first-conv shape (old ckpts won't load into it). Both are zero-init ⇒ identical to teacher at step 0.
+
+Confirmed matching (config): K=5, lr 5e-5, AdamW(0.9,0.95), wd 0, EMA 0.999, 3000 iters,
+λ_gan 3e-3, λ_lpips 2.0, κ=2.0, exp-0.3/15-step/xstart, image-space LPIPS, w_t weighting off
+(`normalize_generator_loss_by_t_power_ten: False`). Deliberate deltas retained: **v2 teacher**
+(vs paper's v1) and **art + light degradation** (vs ImageNet + Real-ESRGAN). Our `dc_loss`
+color term is an addition (official `mse_loss` is off).
+
 ## Forward process (ResShift, from `gaussian_diffusion.py`, verified)
 
 - `q_sample(x0, y0, t)`: `x_t = η_t·(y0 − x0) + x0 + κ·√η_t·ε`  (Eq 4; `e0=y0−x0`).

--- a/sr/distill_rsd/dry_run.py
+++ b/sr/distill_rsd/dry_run.py
@@ -14,7 +14,7 @@ import torch.nn.functional as F
 HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(HERE))
 import rsd_models as M  # noqa: E402
-from rsd_models import TEACHER_CKPT, predict_x0  # noqa: E402
+from rsd_models import TEACHER_CKPT, make_eps, predict_x0  # noqa: E402
 
 
 def main():
@@ -64,7 +64,7 @@ def main():
     print("fake-critic update...")
     z0, z_y = sample_latents()
     t_n = torch.tensor([N_NODES[0]] * B, device=dev).long()
-    eps = torch.randn_like(z0)
+    eps = make_eps(student, z0)
     with torch.no_grad():
         z_tn = diff.q_sample(z0, z_y, t_n)
         z0_hat = predict_x0(diff, student, z_tn, z_y, t_n, eps)  # student output (frozen here)
@@ -84,7 +84,7 @@ def main():
     print("generator update...")
     z0, z_y = sample_latents()
     t_n = torch.tensor([N_NODES[0]] * B, device=dev).long()
-    eps = torch.randn_like(z0)
+    eps = make_eps(student, z0)
     z_tn = diff.q_sample(z0, z_y, t_n)
     z0_hat = predict_x0(diff, student, z_tn, z_y, t_n, eps)        # grad
     t = torch.randint(0, T, (B,), device=dev).long()
@@ -98,7 +98,7 @@ def main():
     # LPIPS single-step path from t=T-1
     z_TT = z_y + diff.kappa * torch.randn_like(z_y)
     tT = torch.tensor([T - 1] * B, device=dev).long()
-    z0_single = predict_x0(diff, student, z_TT, z_y, tT, torch.randn_like(z_y))
+    z0_single = predict_x0(diff, student, z_TT, z_y, tT, make_eps(student, z_y))
     x0_img = vqgan.decode(z0_single, force_not_quantize=True).clamp(-1, 1)
     gt_img = torch.rand(B, 3, 256, 256, device=dev) * 2 - 1
     L_lpips = lp(x0_img, gt_img).mean()

--- a/sr/distill_rsd/infer.py
+++ b/sr/distill_rsd/infer.py
@@ -19,7 +19,7 @@ from tqdm import tqdm
 HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(HERE))
 import rsd_models as M  # noqa: E402
-from rsd_models import TEACHER_CKPT, predict_x0  # noqa: E402
+from rsd_models import TEACHER_CKPT, make_eps, predict_x0  # noqa: E402
 from utils.util_image import ImageSpliterTh  # noqa: E402  (resshift path added by rsd_models)
 
 REPO = M.REPO
@@ -65,7 +65,7 @@ def _sample_tile(cfg, diff, vqgan, student, hr_t, offset, device, amp=True):
     z_T = z_y + diff.kappa * torch.randn_like(z_y)
     tT = torch.full((z_y.shape[0],), diff.num_timesteps - 1, device=device, dtype=torch.long)
     with ctx:
-        z0 = predict_x0(diff, student, z_T, z_y, tT, torch.randn_like(z_y))
+        z0 = predict_x0(diff, student, z_T, z_y, tT, make_eps(student, z_y))
     img = vqgan.decode(z0.to(vdt), force_not_quantize=True).clamp(-1, 1)
     return img[:, :, :h, :w].float()
 
@@ -119,11 +119,15 @@ def main():
         # native bf16 VAE — halves the full-res GroupNorm activations that autocast would
         # otherwise keep in fp32 (the VRAM peak). Codebook is unused (force_not_quantize).
         vqgan = vqgan.to(torch.bfloat16)
-    student = M.build_generator(cfg, str(TEACHER_CKPT), dev, pretrained=False)
     sd = torch.load(ckpt, map_location="cpu")
+    # rebuild the noise-injection arch the ckpt was trained with (ckpt_meta from train.py;
+    # old ckpts predate it -> default to the "add" reconstruction).
+    student = M.build_generator(cfg, str(TEACHER_CKPT), dev, pretrained=False,
+                                noise_mode=sd.get("noise_mode", "add"),
+                                noise_channels=sd.get("noise_channels"))
     key = args.weights if args.weights in sd else ("ema" if "ema" in sd else None)
     student.load_state_dict(sd[key] if key else sd, strict=True)
-    print(f"weights: {key or 'raw'}")
+    print(f"weights: {key or 'raw'} | noise_mode: {student.noise_mode}({student.noise_channels}ch)")
     student.eval()
     if args.compile:
         # Bump the recompile ceiling: dynamic=True still specializes on a few discrete

--- a/sr/distill_rsd/rsd_models.py
+++ b/sr/distill_rsd/rsd_models.py
@@ -72,17 +72,43 @@ def enable_grad_checkpointing(model):
 class StochasticUNet(UNetModelSwin):
     """UNetModelSwin + a zero-init noise branch -> stochastic one-step generator.
 
-    forward(x, timesteps, lq, eps): adds noise_proj(eps) after the first input conv.
-    encode_features(x, lq, t): returns the bottleneck feature map for the GAN head.
+    Two injection modes (both zero-init => bit-identical to the frozen teacher at step 0):
+      - "add" (this reconstruction's default): a separate zero-init conv `noise_proj`
+        maps a 3-channel eps to the post-conv width and is ADDED after input_blocks[0].
+      - "concat" (matches the official RSD release, `sampler.py::_add_noise` /
+        `trainer.py:1426`): WIDEN input_blocks[0][0] by `noise_channels` (default 1) input
+        planes, zero-init on the new slice, and CONCAT eps onto the [latent, lq] stack
+        before the first conv. This is the published mechanism; kept behind a flag because
+        it changes the first-conv shape (existing "add" checkpoints don't load into it).
+
+    forward(x, timesteps, lq, eps): injects eps per `noise_mode`.
+    encode_features(x, lq, t, eps): returns the bottleneck feature map for the GAN head.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, noise_mode="add", noise_channels=None, **kwargs):
         super().__init__(*args, **kwargs)
-        in_lat = self.input_blocks[0][0].out_channels  # post-conv width (160)
-        # eps has the latent's channel count (3); project to the post-conv width.
-        self.noise_proj = nn.Conv2d(3, in_lat, 3, padding=1)
-        nn.init.zeros_(self.noise_proj.weight)
-        nn.init.zeros_(self.noise_proj.bias)
+        self.noise_mode = noise_mode
+        # default channel count differs by mode: 3 (add, latent-shaped) vs 1 (concat, official)
+        self.noise_channels = noise_channels if noise_channels is not None \
+            else (1 if noise_mode == "concat" else 3)
+        conv = self.input_blocks[0][0]
+        if noise_mode == "add":
+            in_lat = conv.out_channels  # post-conv width (160)
+            self.noise_proj = nn.Conv2d(self.noise_channels, in_lat, 3, padding=1)
+            nn.init.zeros_(self.noise_proj.weight)
+            nn.init.zeros_(self.noise_proj.bias)
+        elif noise_mode == "concat":
+            # widen the first input conv: [in_ch] -> [in_ch + noise_channels], zero everywhere
+            # then copy the teacher's original in-planes back; the noise slice stays zero.
+            wide = nn.Conv2d(conv.in_channels + self.noise_channels, conv.out_channels,
+                             conv.kernel_size, padding=conv.padding)
+            with torch.no_grad():
+                nn.init.zeros_(wide.weight)
+                wide.weight[:, :conv.in_channels].copy_(conv.weight)
+                wide.bias.copy_(conv.bias)
+            self.input_blocks[0][0] = wide
+        else:
+            raise ValueError(f"noise_mode must be 'add' or 'concat', got {noise_mode!r}")
 
     def _embed_and_concat(self, x, timesteps, lq):
         emb = self.time_embed(
@@ -98,13 +124,25 @@ class StochasticUNet(UNetModelSwin):
         from models.unet import timestep_embedding
         return timestep_embedding(timesteps, self.model_channels)
 
+    def _inject_concat(self, h, eps):
+        """concat mode: append eps onto the [latent, lq] stack before the first conv."""
+        if self.noise_mode == "concat" and eps is not None:
+            h = torch.cat([h, eps.type(self.dtype)], dim=1)
+        return h
+
+    def _inject_add(self, h, ii, eps):
+        """add mode: add noise_proj(eps) after input_blocks[0]."""
+        if self.noise_mode == "add" and ii == 0 and eps is not None:
+            h = h + self.noise_proj(eps.type(self.dtype))
+        return h
+
     def forward(self, x, timesteps, lq=None, eps=None, mask=None):
         h, emb = self._embed_and_concat(x, timesteps, lq)
+        h = self._inject_concat(h, eps)
         hs = []
         for ii, module in enumerate(self.input_blocks):
             h = module(h, emb)
-            if ii == 0 and eps is not None:
-                h = h + self.noise_proj(eps.type(self.dtype))
+            h = self._inject_add(h, ii, eps)
             hs.append(h)
         h = self.middle_block(h, emb)
         for module in self.output_blocks:
@@ -118,13 +156,23 @@ class StochasticUNet(UNetModelSwin):
         if timesteps is None:
             timesteps = torch.zeros(x.shape[0], device=x.device, dtype=torch.long)
         h, emb = self._embed_and_concat(x, timesteps, lq)
+        h = self._inject_concat(h, eps)
         for ii, module in enumerate(self.input_blocks):
             h = module(h, emb)
-            if ii == 0 and eps is not None:
-                h = h + self.noise_proj(eps.type(self.dtype))
+            h = self._inject_add(h, ii, eps)
         # first sub-module of middle_block is the ResBlock -> bottleneck feats
         h = self.middle_block[0](h, emb)
         return h  # [B, 640, 8, 8]
+
+
+def make_eps(model, ref):
+    """Injection noise shaped for `model`'s mode: (B, model.noise_channels, H, W), like `ref`.
+
+    add mode wants 3 planes (latent-shaped), concat mode wants 1 (official). Use this for the
+    injected eps everywhere the student/fake is called — NOT for the residual-shift diffusion
+    noise (that stays latent-shaped, 3-ch, e.g. `z_T = z_y + kappa*randn_like(z_y)`)."""
+    return torch.randn(ref.shape[0], model.noise_channels, *ref.shape[2:],
+                       device=ref.device, dtype=ref.dtype)
 
 
 class DiscHead(nn.Module):
@@ -159,22 +207,34 @@ def build_teacher(cfg, ckpt_path, device, dtype=torch.float32):
 
 
 def build_generator(cfg, teacher_ckpt, device, dtype=torch.float32, grad_ckpt=False,
-                    pretrained=True):
-    """Student or fake: teacher weights + zero-init noise branch (strict=False).
+                    pretrained=True, noise_mode="add", noise_channels=None):
+    """Student or fake: teacher weights + zero-init noise branch.
 
+    noise_mode "add" (default) / "concat" (official RSD) — see StochasticUNet.
     grad_ckpt=True enables Swin-attention gradient checkpointing (training only) —
     large activation-memory save, bit-exact. Leave off for inference.
     pretrained=False skips loading the teacher ckpt (random init) — use when the caller
     immediately load_state_dict's a full student ckpt over it (avoids a wasted 174M read).
     """
-    model = _build_unet(cfg, StochasticUNet)
+    params = OmegaConf.to_container(cfg.model.params, resolve=True)
+    model = StochasticUNet(noise_mode=noise_mode, noise_channels=noise_channels, **params)
     if pretrained:
-        sd = torch.load(teacher_ckpt, map_location="cpu")
+        sd = _strip_module(torch.load(teacher_ckpt, map_location="cpu"))
         sd = sd["state_dict"] if isinstance(sd, dict) and "state_dict" in sd else sd
-        missing, unexpected = model.load_state_dict(_strip_module(sd), strict=False)
-        # only noise_proj.* should be missing from the ckpt
-        assert all("noise_proj" in m for m in missing), f"unexpected missing: {missing}"
-        assert not unexpected, f"unexpected keys: {unexpected}"
+        if model.noise_mode == "concat":
+            # teacher's first conv is narrower than our widened one; graft the teacher planes
+            # into the leading slice (noise slice stays zero-init) so load stays strict.
+            key = "input_blocks.0.0.weight"
+            tw = sd[key]
+            w = model.state_dict()[key].clone()   # zeros on the noise slice
+            w[:, :tw.shape[1]].copy_(tw)
+            sd = {**sd, key: w}
+            model.load_state_dict(sd, strict=True)
+        else:
+            missing, unexpected = model.load_state_dict(sd, strict=False)
+            # only noise_proj.* should be missing from the ckpt
+            assert all("noise_proj" in m for m in missing), f"unexpected missing: {missing}"
+            assert not unexpected, f"unexpected keys: {unexpected}"
     if grad_ckpt:
         enable_grad_checkpointing(model)
     return model.to(device, dtype)

--- a/sr/distill_rsd/train.py
+++ b/sr/distill_rsd/train.py
@@ -21,7 +21,7 @@ HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(HERE))
 import rsd_models as M  # noqa: E402
 from data import ArtSRDataset  # noqa: E402
-from rsd_models import TEACHER_CKPT, predict_x0  # noqa: E402
+from rsd_models import TEACHER_CKPT, make_eps, predict_x0  # noqa: E402
 
 
 @torch.no_grad()
@@ -61,6 +61,18 @@ def main():
     ap.add_argument("--ema", type=float, default=0.999)
     ap.add_argument("--nodes", type=int, nargs="+", default=[4, 8, 12, 14],
                     help="N multistep timestep nodes (0-indexed in [0,T-1])")
+    ap.add_argument("--sid_denom", choices=["student", "input"], default="student",
+                    help="SiD per-sample normalization denominator for the DMD gradient. "
+                         "'student' = |teacher_x0 - student_x0| + 1e-8 (matches official RSD "
+                         "release, trainer.py:1836); 'input' = |z_t - teacher_x0| floored 0.05 "
+                         "(this reconstruction's original form).")
+    ap.add_argument("--noise_mode", choices=["add", "concat"], default="add",
+                    help="student/fake noise injection. 'add' = zero-init 3ch conv added after "
+                         "block0 (default, back-compatible with existing checkpoints); 'concat' = "
+                         "widen the first conv by noise_channels and concat eps (matches official "
+                         "RSD release — changes the first-conv shape, so old ckpts won't load).")
+    ap.add_argument("--noise_channels", type=int, default=None,
+                    help="injected-noise channel count (default 3 for add, 1 for concat/official)")
     ap.add_argument("--amp", action="store_true", help="bf16 autocast")
     ap.add_argument("--no_grad_ckpt", action="store_true",
                     help="disable Swin gradient checkpointing on student/fake (on by "
@@ -82,9 +94,10 @@ def main():
     sf_scale = cfg.diffusion.params.scale_factor
 
     print("building nets...")
+    gen_kw = dict(noise_mode=args.noise_mode, noise_channels=args.noise_channels)
     teacher = M.build_teacher(cfg, str(TEACHER_CKPT), dev)
-    student = M.build_generator(cfg, str(TEACHER_CKPT), dev, grad_ckpt=not args.no_grad_ckpt)
-    fake = M.build_generator(cfg, str(TEACHER_CKPT), dev, grad_ckpt=not args.no_grad_ckpt)
+    student = M.build_generator(cfg, str(TEACHER_CKPT), dev, grad_ckpt=not args.no_grad_ckpt, **gen_kw)
+    fake = M.build_generator(cfg, str(TEACHER_CKPT), dev, grad_ckpt=not args.no_grad_ckpt, **gen_kw)
     disc = M.DiscHead().to(dev)
     vqgan = M.build_autoencoder(cfg, dev)
     diff = M.build_diffusion(cfg)
@@ -92,6 +105,9 @@ def main():
     ema = copy.deepcopy(student).eval()
     for p in ema.parameters():
         p.requires_grad_(False)
+    # provenance for inference (rebuilds the matching noise-injection arch) + A/B tracking
+    ckpt_meta = {"noise_mode": student.noise_mode, "noise_channels": student.noise_channels,
+                 "sid_denom": args.sid_denom}
 
     import lpips
     lp = lpips.LPIPS(net="vgg").to(dev).eval()
@@ -139,7 +155,7 @@ def main():
             opt_f.zero_grad(set_to_none=True)
             gt, lq = next_batch(); B = gt.shape[0]
             z0, z_y = encode(gt, lq)
-            t_n = rand_t(B, nodes); eps = torch.randn_like(z0)
+            t_n = rand_t(B, nodes); eps = make_eps(student, z0)
             with torch.no_grad(), autocast():
                 z_tn = diff.q_sample(z0, z_y, t_n)
                 z0_hat = predict_x0(diff, student, z_tn, z_y, t_n, eps)
@@ -160,7 +176,7 @@ def main():
         for _ in range(args.grad_accum):
             gt, lq = next_batch(); B = gt.shape[0]
             z0, z_y = encode(gt, lq)
-            t_n = rand_t(B, nodes); eps = torch.randn_like(z0)
+            t_n = rand_t(B, nodes); eps = make_eps(student, z0)
             z_tn = diff.q_sample(z0, z_y, t_n)
             with autocast():
                 z0_hat = predict_x0(diff, student, z_tn, z_y, t_n, eps)
@@ -170,22 +186,26 @@ def main():
                 x0_teacher = predict_x0(diff, teacher, z_t, z_y, t)
                 x0_fakep = predict_x0(diff, fake, z_t, z_y, t, eps)
                 # DMD/SiD per-sample normalization (App C, "loss normalization … SiD"):
-                # divide by a TEACHER-derived magnitude — the residual the teacher still
-                # removes, ‖z_t − f*_x0‖ (DESIGN) — NOT by the (fake−teacher) diff's own
-                # norm. Self-normalizing flattens the distribution-matching signal (every
-                # sample gets a unit push regardless of how wrong it is) and, lacking a
-                # real floor, amplifies critic noise to unit scale once fake≈teacher.
-                # Floor 0.05 mirrors turbo_dmd's norm_floor (scripts/distill_turbo).
+                # divide the (fake−teacher) push by a TEACHER-derived magnitude — NOT by the
+                # (fake−teacher) diff's own norm (self-normalizing flattens the
+                # distribution-matching signal so every sample gets a unit push regardless of
+                # how wrong it is, and amplifies critic noise once fake≈teacher).
                 grad = (x0_fakep - x0_teacher).float()
-                denom = (z_t.float() - x0_teacher.float()).abs().mean(
-                    dim=[1, 2, 3], keepdim=True).clamp_min(0.05)
+                if args.sid_denom == "student":
+                    # official RSD release (trainer.py:1836): |teacher_x0 − student_x0| + 1e-8
+                    denom = (x0_teacher.float() - z0_hat.detach().float()).abs().mean(
+                        dim=[1, 2, 3], keepdim=True) + 1e-8
+                else:
+                    # original reconstruction: ‖z_t − f*_x0‖ floored 0.05 (turbo_dmd norm_floor)
+                    denom = (z_t.float() - x0_teacher.float()).abs().mean(
+                        dim=[1, 2, 3], keepdim=True).clamp_min(0.05)
                 grad = grad / denom
             L_theta = 0.5 * F.mse_loss(z0_hat.float(), (z0_hat.float() - grad).detach())
             # single-step LPIPS path from z_T ~ N(z_y, kappa^2)
             z_TT = z_y + diff.kappa * torch.randn_like(z_y)
             tT = torch.full((B,), T - 1, device=dev, dtype=torch.long)
             with autocast():
-                z0_single = predict_x0(diff, student, z_TT, z_y, tT, torch.randn_like(z_y))
+                z0_single = predict_x0(diff, student, z_TT, z_y, tT, make_eps(student, z_y))
                 x0_img = vqgan.decode(z0_single.float(), force_not_quantize=True).clamp(-1, 1)
                 L_lpips = lp(x0_img, gt).mean()
                 L_dc = dc_loss(x0_img.float(), gt.float())
@@ -208,14 +228,14 @@ def main():
             with open(log_path, "a") as f:
                 f.write(json.dumps(line) + "\n")
         if step > 0 and step % args.save_every == 0:
-            torch.save({"ema": ema.state_dict(), "student": student.state_dict(), "step": step},
-                       save_dir / f"rsd_student_{step}.pth")
+            torch.save({"ema": ema.state_dict(), "student": student.state_dict(), "step": step,
+                        **ckpt_meta}, save_dir / f"rsd_student_{step}.pth")
         if args.max_steps and step + 1 >= args.max_steps:
             print(f"max_steps {args.max_steps} hit — stopping (smoke).")
             break
 
-    torch.save({"ema": ema.state_dict(), "student": student.state_dict(), "step": args.iters},
-               save_dir / "rsd_student_final.pth")
+    torch.save({"ema": ema.state_dict(), "student": student.state_dict(), "step": args.iters,
+                **ckpt_meta}, save_dir / "rsd_student_final.pth")
     print(f"done. saved to {save_dir}")
 
 


### PR DESCRIPTION
## Context

The RSD authors ([One-Step Residual Shifting Diffusion for Image SR via Distillation](https://openreview.net/pdf?id=3WTFzAFHr3), ICML 2026) released their code. `sr/distill_rsd/` was a **from-paper reconstruction** (the repo was a "Coming soon" placeholder at the time). This PR reconciles the two.

**Caveat on the release:** it ships orchestration only (`trainer.py` / `sampler.py` / `main_distill.py` / config / data pipeline) and **omits the entire `models/` package** — the DMD-core `training_student_losses` / `training_fake_losses`, the GAN wrapper `UNetModelSwinGanWrapper`, and the noise-consuming UNet `forward`. SinSR (the base repo) supplies only `UNetModelSwin` + `create_gaussian_diffusion`, not those RSD additions. So the generator-gradient form and the exact N=4 node timesteps are **still not publicly verifiable**; watch upstream for the missing package.

## What changed

Two mechanisms observable from the config + `trainer.py` diverged from the reconstruction. Both are now flag-selectable and backward-compatible.

| Item | Official | This PR |
|---|---|---|
| **SiD normalization** (`--sid_denom`) | `\|teacher_x0 − student_x0\| + 1e-8` (`trainer.py:1836`) | **default → `student` (official)**; `input` keeps the old `\|z_t − teacher_x0\|` floored 0.05. Training-only, no ckpt change. |
| **Noise injection** (`--noise_mode`) | widen first conv by `noise_channels=1`, **concat** eps (`sampler.py:79`) | adds `concat` mode; **default stays `add`** (existing ckpts load). Both zero-init ⇒ bit-identical to teacher at step 0. |

- Checkpoints now record `{noise_mode, noise_channels, sid_denom}`; `infer.py` rebuilds the matching arch (old ckpts default to `add`).
- `make_eps()` shapes the injected noise per mode; `dry_run.py` / `infer.py` updated.
- `DESIGN.md` gains an "Official release reconciliation" section + the confirmed-matching hyperparameters (K=5, lr 5e-5, AdamW(0.9,0.95), EMA 0.999, 3000 iters, λ_gan 3e-3, λ_lpips 2.0, κ=2.0, w_t off).

Retained deliberate deltas: **v2 teacher** (vs paper v1), **art + light degradation** (vs ImageNet + Real-ESRGAN), and the `dc_loss` color term (an addition; official `mse_loss` is off).

## Testing

Verified locally (CPU/torch-only): `py_compile` clean on all four files, and the concat-mode zero-init reproduces the teacher output exactly regardless of injected noise. **Not run on GPU** — intended for A/B on this branch before merge:
- `--sid_denom student` (new default) vs `--sid_denom input` (old)
- `--noise_mode concat` (fresh run; not ckpt-compatible with `add`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)