### PR TITLE
bench/uncond_soup: Self-Soupervision Phase 0 (uncond inter-train + soup vs plain soup)

### DIFF
--- a/bench/uncond_soup/README.md
+++ b/bench/uncond_soup/README.md
@@ -1,0 +1,105 @@
+# uncond_soup — does soup-with-uncond really help?
+
+Phase 0 of the Self-Soupervision question (Fuller, Green & Shelhamer,
+arXiv:2602.02890): model soups whose ingredients are prepared by a
+**label-free inter-training** stage. For a flow-matching DiT the natural
+"SSL" is unconditional training — the FM objective needs no labels; the
+caption is the only label in this pipeline — so the recipe maps to:
+
+```
+Anima base (stock)
+  └─ uncond inter-train on a bounded 3-artist pool     caption_dropout_rate=1.0
+       ├─ captioned fine-tune, target artist, seed 1   ┐
+       ├─ captioned fine-tune, target artist, seed 2   ├─ "self" family
+       └─ captioned fine-tune, target artist, seed 3   ┘
+                                        └── uniform ΔW soup = self:soup
+Anima base (stock)
+       ├─ captioned fine-tune, target artist, seed 1   ┐
+       ├─ captioned fine-tune, target artist, seed 2   ├─ "base" family (control)
+       └─ captioned fine-tune, target artist, seed 3   ┘
+                                        └── uniform ΔW soup = base:soup
+```
+
+The two families share fine-tuning seeds (paired data order + FM training
+noise), so the only difference is the unconditional initialization. This also
+makes the bench a seed-lottery mitigation test (arXiv:2606.20536, "The FID
+Lottery"): souping over training seeds averages over the training lottery,
+and every gate below is judged against the sampling-noise floor
+`sigma_within` rather than raw deltas.
+
+## Scope guards
+
+- **Bounded pool**: exactly 3 artists for the uncond phase (the target artist
+  should be one of them — matching the paper's "inter-train on unlabeled data
+  from the task" setting). Supervision = single artist.
+- **Plain LoRA only** (the lora.toml default: `down_init="weight_svd"`,
+  optional T-LoRA). SVD-Down matters here: it pins every seed's A-init to
+  top-r(W₀), putting the ingredients in the shared-init/different-stochasticity
+  regime where linear mode connectivity (LMC) is empirically strongest.
+  Hydra/chimera/ortho checkpoints are refused by the soup builder.
+- **Soup is at the ΔW level, exactly** — a weighted average of rank-r deltas
+  is representable without approximation as one rank-N·r LoRA by block
+  concatenation (`soup.py`). Parameterwise (A/B) averaging is wrong and is
+  never done: `avg(B)@avg(A) ≠ avg(B@A)`, and weight_svd's randomized-SVD
+  sign ambiguity would make row-wise A averaging cancel.
+
+## Files
+
+| File | Role |
+|---|---|
+| `launch.py` | Emits the 7 training commands (1 pool + 2×3 fine-tunes). Prints; `--write runs.sh` to save. Never launches. |
+| `soup.py` | Exact ΔW-average soup / λ-interpolation builder (also a library for `probe.py`). Folds alpha and channel-scaling `inv_scale` per ingredient; output has `alpha = rank` (scale 1) and carries soup provenance in metadata. |
+| `probe.py` | CMMD-scores all arms against the target artist's held-out split and reduces to the gates. Reuses `bench/seed_lottery/probe.py`'s trainer-faithful split + compile + CMMD loop. |
+
+## Running
+
+```bash
+# 1. Plan the runs (pick 3 artist dirs under post_image_dataset/resized/)
+python bench/uncond_soup/launch.py --pool_artists artistA artistB artistC
+
+# 2. Run/queue the 7 printed train.py commands (pool first — the self family
+#    fine-tunes load its checkpoint via --network_weights).
+
+# 3. Score (the launch output prints this line with paths filled in)
+python bench/uncond_soup/probe.py --method lora --preset default \
+    --target_artist artistA \
+    --self_ckpts output/ckpt/uncondsoup_self_s100{1,2,3}.safetensors \
+    --base_ckpts output/ckpt/uncondsoup_base_s100{1,2,3}.safetensors \
+    --pool_ckpt output/ckpt/uncondsoup_pool.safetensors \
+    --validation_split_num 16 --validation_seed 42
+```
+
+`--validation_split_num` / `--validation_seed` must match between launch and
+probe — that is what makes the held-out set the one no run ever saw. The
+uncond phase still requires TE caches on disk (embeddings are loaded, then
+dropped rows are swapped to the T5("") sidecar, which `train.py` stages
+automatically when caption dropout is on).
+
+## Gates (CMMD, lower = better)
+
+1. **LMC** — every λ=0.5 pair midpoint within a family must satisfy
+   `cmmd(mid) ≤ mean(endpoints) + sigma_within`. If this fails, souping's
+   premise is broken and the verdict short-circuits to `LMC_FAILS`
+   (fix init sharing before re-running — e.g. branch fine-tunes from one
+   saved init, or pin the weight_svd RNG).
+2. **SOUP** — `soup ≤ best ingredient + sigma_within` per family (souping at
+   least doesn't lose to seed-fishing).
+3. **UNCOND (headline)** — `base_soup − self_soup > gate_mult·sigma_within`
+   → `UNCOND_HELPS`; symmetric for `UNCOND_HURTS`; else inconclusive.
+
+## Caveats / non-goals
+
+- **Not compute-matched**: the self family gets the pool pre-train for free.
+  A `UNCOND_HELPS` here licenses a Phase 1 with an equal-budget control
+  (e.g. base family trained `pool_epochs` longer), not a shipping decision.
+- The expected effect size is modest when all fine-tune data is already
+  captioned — the paper's headline gains came from *shifted/unlabeled target*
+  data. The interesting follow-up if Phase 0 passes: pools of genuinely
+  uncaptioned images.
+- `sigma_within` here is the *sampling* floor (K val seeds per fixed arm).
+  The between-training-seed floor is `bench/seed_lottery/`'s job; with N=3
+  ingredients this bench can't estimate it reliably and doesn't try.
+- Memory guard: unconditional training pushes content into the
+  style/unconditional pathway (see `project_lora_crossattn_learns_labeled_only`)
+  and reshapes the CFG-uncond branch. Eyeball the contact sheet, not just the
+  numbers.

--- a/bench/uncond_soup/launch.py
+++ b/bench/uncond_soup/launch.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Emit the training commands for the uncond-soup bench (see README.md).
+
+Seven runs total with the defaults (1 pool pre-train + 2 families x N=3
+paired-seed fine-tunes). This script does NOT launch anything — it prints the
+exact ``python train.py`` command lines (and optionally writes them to a shell
+script) so they can be run inline, or queued on the daemon one at a time.
+
+The two families share the same fine-tuning seeds (paired draws: identical
+data order + FM training noise per seed), so the only difference between
+``self_s<k>`` and ``base_s<k>`` is the unconditional inter-trained
+initialization. That pairing is what lets the probe attribute soup-level
+deltas to the uncond phase rather than to seed luck.
+
+Usage
+-----
+    python bench/uncond_soup/launch.py \
+        --pool_artists artistA artistB artistC \
+        [--target_artist artistA] [--n_seeds 3] [--seed_base 1000] \
+        [--write runs.sh]
+"""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from library.datasets.artist_shard import _pattern_for, list_artists  # noqa: E402
+
+PREFIX = "uncondsoup"
+
+
+def build_commands(args) -> list[tuple[str, list[str]]]:
+    """[(label, argv), ...] for every training run in the plan."""
+    common = [
+        "python",
+        "train.py",
+        "--method",
+        args.method,
+        "--preset",
+        args.preset,
+        "--validation_split_num",
+        str(args.validation_split_num),
+        "--validation_seed",
+        str(args.validation_seed),
+    ]
+    pool_pattern = _pattern_for(args.pool_artists)
+    target_pattern = _pattern_for([args.target_artist])
+
+    cmds: list[tuple[str, list[str]]] = []
+
+    # Phase A — unconditional inter-train on the 3-artist pool. Captions are
+    # dropped 100% of the time; dropped rows get the T5("") sidecar (staged
+    # automatically by train.py when caption dropout is on), so the adapter
+    # sees the same uncond embedding CFG-uncond inference feeds.
+    pool = common + [
+        "--path_pattern",
+        pool_pattern,
+        "--caption_dropout_rate",
+        "1.0",
+        "--seed",
+        str(args.seed_base),
+        "--output_name",
+        f"{PREFIX}_pool",
+    ]
+    if args.pool_epochs is not None:
+        pool += ["--max_train_epochs", str(args.pool_epochs)]
+    cmds.append(("pool (uncond inter-train)", pool))
+
+    pool_ckpt = f"output/ckpt/{PREFIX}_pool.safetensors"
+    for k in range(1, args.n_seeds + 1):
+        seed = args.seed_base + k
+        ft_common = common + ["--path_pattern", target_pattern, "--seed", str(seed)]
+        if args.ft_epochs is not None:
+            ft_common += ["--max_train_epochs", str(args.ft_epochs)]
+        cmds.append(
+            (
+                f"self ingredient s{seed}",
+                ft_common
+                + [
+                    "--network_weights",
+                    pool_ckpt,
+                    "--output_name",
+                    f"{PREFIX}_self_s{seed}",
+                ],
+            )
+        )
+        cmds.append(
+            (
+                f"base ingredient s{seed}",
+                ft_common + ["--output_name", f"{PREFIX}_base_s{seed}"],
+            )
+        )
+    return cmds
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--pool_artists",
+        nargs=3,
+        required=True,
+        metavar="ARTIST",
+        help="Exactly 3 artist subdirectory names — the bounded unlabeled pool.",
+    )
+    ap.add_argument(
+        "--target_artist",
+        default=None,
+        help="Supervised fine-tune artist (default: first of --pool_artists).",
+    )
+    ap.add_argument("--n_seeds", type=int, default=3, help="Ingredients per family.")
+    ap.add_argument("--seed_base", type=int, default=1000)
+    ap.add_argument("--method", default="lora")
+    ap.add_argument("--preset", default="default")
+    ap.add_argument(
+        "--validation_split_num",
+        type=int,
+        default=16,
+        help="Held-out split size — the probe MUST be run with the same value.",
+    )
+    ap.add_argument("--validation_seed", type=int, default=42)
+    ap.add_argument(
+        "--pool_epochs",
+        type=int,
+        default=None,
+        help="Epoch override for the uncond pool run (default: method config).",
+    )
+    ap.add_argument(
+        "--ft_epochs",
+        type=int,
+        default=None,
+        help="Epoch override for every fine-tune (default: method config).",
+    )
+    ap.add_argument(
+        "--image_dir",
+        default="post_image_dataset/resized",
+        help="Where to verify the artist subdirectories exist.",
+    )
+    ap.add_argument("--write", default=None, help="Also write the commands here (.sh).")
+    args = ap.parse_args()
+
+    if args.target_artist is None:
+        args.target_artist = args.pool_artists[0]
+
+    known = set(list_artists(str(REPO_ROOT / args.image_dir)))
+    for a in set(args.pool_artists) | {args.target_artist}:
+        if known and a not in known:
+            print(f"WARNING: artist dir {a!r} not found under {args.image_dir}")
+
+    cmds = build_commands(args)
+    lines = [" ".join(shlex.quote(t) for t in argv) for _label, argv in cmds]
+
+    print(f"# uncond-soup bench: {len(cmds)} training runs")
+    print(f"# pool = {args.pool_artists}  target = {args.target_artist}")
+    print("# Run sequentially (or submit each to the daemon queue).\n")
+    for (label, _argv), line in zip(cmds, lines):
+        print(f"# {label}")
+        print(line, "\n")
+
+    self_ckpts = " ".join(
+        f"output/ckpt/{PREFIX}_self_s{args.seed_base + k}.safetensors"
+        for k in range(1, args.n_seeds + 1)
+    )
+    base_ckpts = " ".join(
+        f"output/ckpt/{PREFIX}_base_s{args.seed_base + k}.safetensors"
+        for k in range(1, args.n_seeds + 1)
+    )
+    print("# Then score everything:")
+    print(
+        f"python bench/uncond_soup/probe.py --method {args.method} "
+        f"--preset {args.preset} --target_artist {shlex.quote(args.target_artist)} "
+        f"--self_ckpts {self_ckpts} --base_ckpts {base_ckpts} "
+        f"--pool_ckpt output/ckpt/{PREFIX}_pool.safetensors "
+        f"--validation_split_num {args.validation_split_num} "
+        f"--validation_seed {args.validation_seed}"
+    )
+
+    if args.write:
+        out = Path(args.write)
+        body = "\n".join(f"# {label}\n{line}" for (label, _a), line in zip(cmds, lines))
+        out.write_text(f"#!/usr/bin/env bash\nset -euo pipefail\n\n{body}\n")
+        print(f"\nWrote {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/uncond_soup/probe.py
+++ b/bench/uncond_soup/probe.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Does soup-with-uncond really help? (Self-Soupervision Phase 0)
+
+Design (see README.md): a 3-artist bounded pool provides the *unlabeled* data
+for an unconditional inter-train (caption_dropout_rate=1.0); supervision is a
+single artist. Two ingredient families share the same fine-tuning seeds:
+
+    base_s<k>  = plain fine-tune on the target artist          (seed k)
+    self_s<k>  = same fine-tune, initialized from the uncond   (seed k)
+                 pool checkpoint via --network_weights
+
+This probe CMMD-scores, against the target artist's held-out split:
+
+    every ingredient, each family's uniform DW soup, each family's
+    lambda=0.5 pair midpoints (the LMC gate), and optionally the raw
+    uncond pool checkpoint (sanity: should be clearly worse).
+
+Gates (CMMD: lower is better; sigma_within = sampling-noise floor, the
+FID-lottery correction — deltas below it are inconclusive):
+
+    LMC        mid(a,b) <= mean(cmmd_a, cmmd_b) + sigma_within, all pairs,
+               both families. If this fails, souping is off the table and
+               every other number here is moot.
+    SOUP       family soup <= best ingredient + sigma_within
+               (soup at least doesn't lose to seed-fishing).
+    UNCOND     headline: base_soup_mean - self_soup_mean > gate_mult *
+               sigma_within  ->  UNCOND_HELPS. Symmetrically UNCOND_HURTS;
+               otherwise INCONCLUSIVE.
+
+Reuses the seed-lottery probe's trainer-faithful split / CMMD / compile
+machinery wholesale — this bench adds only the soup arms and the reduction.
+
+Usage
+-----
+    python bench/uncond_soup/probe.py \
+        --method lora --preset default --target_artist artistA \
+        --self_ckpts output/ckpt/uncondsoup_self_s1001.safetensors ... \
+        --base_ckpts output/ckpt/uncondsoup_base_s1001.safetensors ... \
+        --pool_ckpt  output/ckpt/uncondsoup_pool.safetensors \
+        --validation_split_num 16 --validation_seed 42 --k_val 3
+
+``--validation_split_num`` / ``--validation_seed`` MUST match the training
+runs (launch.py defaults) so the held-out set is the one no run ever saw.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from itertools import combinations
+from pathlib import Path
+from statistics import median
+
+import torch
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from anima_lora import load_vae  # noqa: E402
+from bench._common import make_run_dir, write_result  # noqa: E402
+from bench.seed_lottery.probe import (  # noqa: E402
+    _token_budget,
+    build_training_args,
+    build_val_items,
+    cmmd_for_checkpoint,
+    save_contact_sheet,
+)
+from bench.uncond_soup.soup import build_soup_file  # noqa: E402
+from library.datasets.artist_shard import _pattern_for  # noqa: E402
+from library.runtime.accelerator import prepare_accelerator  # noqa: E402
+from library.runtime.device import str_to_dtype  # noqa: E402
+from library.training.cmmd import load_reference_features  # noqa: E402
+from library.vision.encoder import load_pe_encoder  # noqa: E402
+
+
+def build_arms(args_cli, run_dir: Path) -> list[tuple[str, str]]:
+    """[(arm_name, ckpt_path)] — ingredients + soups + LMC midpoints (+ pool).
+
+    Soup/midpoint files are built into ``run_dir`` so the run is
+    self-contained and re-scoreable.
+    """
+    arms: list[tuple[str, str]] = []
+    for family, ckpts in (
+        ("base", args_cli.base_ckpts),
+        ("self", args_cli.self_ckpts),
+    ):
+        for c in ckpts:
+            arms.append((f"{family}:{Path(c).stem}", c))
+        soup_path = build_soup_file(ckpts, str(run_dir / f"{family}_soup.safetensors"))
+        arms.append((f"{family}:soup", str(soup_path)))
+        for i, j in combinations(range(len(ckpts)), 2):
+            mid = build_soup_file(
+                [ckpts[i], ckpts[j]],
+                str(run_dir / f"{family}_mid{i}{j}.safetensors"),
+                weights=[0.5, 0.5],
+            )
+            arms.append((f"{family}:mid{i}{j}", str(mid)))
+    if args_cli.pool_ckpt:
+        arms.append(("pool", args_cli.pool_ckpt))
+    return arms
+
+
+def reduce_family(
+    family: str,
+    arm_stats: dict[str, dict],
+    n_ingredients: int,
+    sigma_within: float,
+) -> dict:
+    ing = {
+        k: v
+        for k, v in arm_stats.items()
+        if k.startswith(f"{family}:") and ":mid" not in k and k != f"{family}:soup"
+    }
+    soup_mean = arm_stats[f"{family}:soup"]["mean"]
+    best_name, best = min(ing.items(), key=lambda kv: kv[1]["mean"])
+    mids = {k: v for k, v in arm_stats.items() if k.startswith(f"{family}:mid")}
+
+    # Endpoint order = --ckpts order = arm insertion order (dicts preserve it).
+    endpoints = list(ing)
+
+    # LMC per pair: midpoint no worse than the endpoint average, within noise.
+    lmc_pairs = []
+    for mid_name, mid in mids.items():
+        i, j = int(mid_name[-2]), int(mid_name[-1])  # N <= 9 by construction
+        e_i, e_j = endpoints[i], endpoints[j]
+        endpoint_avg = 0.5 * (arm_stats[e_i]["mean"] + arm_stats[e_j]["mean"])
+        holds = mid["mean"] <= endpoint_avg + sigma_within
+        lmc_pairs.append(
+            {
+                "pair": [e_i, e_j],
+                "mid": mid_name,
+                "mid_mean": mid["mean"],
+                "endpoint_avg": endpoint_avg,
+                "holds": bool(holds),
+            }
+        )
+    return {
+        "n_ingredients": n_ingredients,
+        "ingredient_means": {k: v["mean"] for k, v in ing.items()},
+        "best_ingredient": best_name,
+        "best_mean": best["mean"],
+        "soup_mean": soup_mean,
+        "soup_minus_best": soup_mean - best["mean"],
+        "soup_beats_or_ties_best": bool(soup_mean <= best["mean"] + sigma_within),
+        "lmc_pairs": lmc_pairs,
+        "lmc_holds": bool(all(p["holds"] for p in lmc_pairs)),
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--method", default="lora")
+    ap.add_argument("--preset", default="default")
+    ap.add_argument(
+        "--target_artist",
+        required=True,
+        help="Artist subdirectory name the fine-tunes trained on — the probe "
+        "scores against this artist's held-out split.",
+    )
+    ap.add_argument("--self_ckpts", nargs="+", required=True)
+    ap.add_argument("--base_ckpts", nargs="+", required=True)
+    ap.add_argument(
+        "--pool_ckpt",
+        default=None,
+        help="The uncond inter-trained checkpoint (sanity arm; optional).",
+    )
+    ap.add_argument("--k_val", type=int, default=3)
+    ap.add_argument("--val_seed_base", type=int, default=1)
+    ap.add_argument("--validation_split_num", type=int, default=16)
+    ap.add_argument("--validation_seed", type=int, default=42)
+    ap.add_argument("--max_val_items", type=int, default=None)
+    ap.add_argument("--sample_steps", type=int, default=20)
+    ap.add_argument("--cfg", type=float, default=1.0)
+    ap.add_argument("--dtype", type=str, default="bf16")
+    ap.add_argument(
+        "--gate_mult",
+        type=float,
+        default=1.5,
+        help="UNCOND verdict fires when |base_soup - self_soup| exceeds this "
+        "multiple of sigma_within.",
+    )
+    ap.add_argument("--compile", dest="compile", action="store_true", default=True)
+    ap.add_argument("--no-compile", dest="compile", action="store_false")
+    ap.add_argument("--label", default=None)
+    args_cli = ap.parse_args()
+
+    if len(args_cli.self_ckpts) != len(args_cli.base_ckpts):
+        ap.error("--self_ckpts and --base_ckpts must be paired (same length/seeds).")
+    if len(args_cli.self_ckpts) < 2:
+        ap.error("Need >= 2 ingredients per family (soup + LMC need pairs).")
+    if len(args_cli.self_ckpts) > 9:
+        ap.error("Max 9 ingredients per family (single-digit midpoint naming).")
+
+    dtype = str_to_dtype(args_cli.dtype)
+    run_dir = make_run_dir("uncond_soup", label=args_cli.label)
+
+    # Arms first (soup construction is CPU-only and fails fast on bad inputs).
+    arms = build_arms(args_cli, run_dir)
+    print(f"Arms ({len(arms)}): {[n for n, _ in arms]}", flush=True)
+
+    # Trainer-faithful args + the target artist's held-out split.
+    targs = build_training_args(
+        args_cli.method,
+        args_cli.preset,
+        {
+            "validation_split_num": args_cli.validation_split_num,
+            "validation_seed": args_cli.validation_seed,
+            "validation_sample_steps": args_cli.sample_steps,
+            "validation_cfg_scale": args_cli.cfg,
+            "path_pattern": _pattern_for([args_cli.target_artist]),
+        },
+    )
+    acc = prepare_accelerator(targs)
+    items = build_val_items(targs)
+    if args_cli.max_val_items is not None:
+        items = items[: args_cli.max_val_items]
+    if not items:
+        raise RuntimeError(
+            "No held-out items with cached TE + PE sidecars for "
+            f"{args_cli.target_artist!r} — check --validation_split_num/"
+            "--validation_seed match the training runs and `make preprocess-pe` ran."
+        )
+    print(f"Held-out items ({args_cli.target_artist}): {len(items)}", flush=True)
+
+    ref_pool = load_reference_features([pe for (_i, _t, pe) in items]).to(acc.device)
+    pe_bundle = load_pe_encoder(acc.device)
+    pe_bundle.encoder.inner.to("cpu")
+    vae = load_vae(targs.vae, dtype=dtype, eval=True, vae_2d=True, device="cpu")
+    flow_shift = float(getattr(targs, "discrete_flow_shift", 3.0))
+    vseeds = list(
+        range(args_cli.val_seed_base, args_cli.val_seed_base + args_cli.k_val)
+    )
+    compile_budget = _token_budget(items) if args_cli.compile else None
+
+    arm_stats: dict[str, dict] = {}
+    contact_rows: list[list[torch.Tensor]] = []
+    for name, ckpt in arms:
+        row, contact = cmmd_for_checkpoint(
+            ckpt=ckpt,
+            args=targs,
+            acc=acc,
+            vae=vae,
+            pe_bundle=pe_bundle,
+            items=items,
+            ref_pool=ref_pool,
+            vseeds=vseeds,
+            sample_steps=args_cli.sample_steps,
+            cfg_scale=args_cli.cfg,
+            flow_shift=flow_shift,
+            compile_budget=compile_budget,
+        )
+        t = torch.tensor(row)
+        arm_stats[name] = {
+            "cmmd": row,
+            "mean": float(t.mean()),
+            "std": float(t.std(unbiased=True)) if len(row) > 1 else 0.0,
+        }
+        contact_rows.append(contact)
+
+    sigma_within = median(v["std"] for v in arm_stats.values())
+
+    fam = {
+        family: reduce_family(family, arm_stats, len(args_cli.base_ckpts), sigma_within)
+        for family in ("base", "self")
+    }
+    lmc_ok = fam["base"]["lmc_holds"] and fam["self"]["lmc_holds"]
+    uncond_gain = fam["base"]["soup_mean"] - fam["self"]["soup_mean"]
+    floor = args_cli.gate_mult * sigma_within
+    if not lmc_ok:
+        verdict = "LMC_FAILS (souping premise broken — fix init sharing first)"
+    elif uncond_gain > floor:
+        verdict = "UNCOND_HELPS"
+    elif uncond_gain < -floor:
+        verdict = "UNCOND_HURTS"
+    else:
+        verdict = "INCONCLUSIVE (below noise floor)"
+
+    print("\n=== uncond-soup Phase 0 ===")
+    for name in arm_stats:
+        s = arm_stats[name]
+        print(f"  {name:24s} CMMD {s['mean']:.3f} +- {s['std']:.3f}")
+    print(f"sigma_within  = {sigma_within:.4f}")
+    for family in ("base", "self"):
+        f = fam[family]
+        print(
+            f"{family}: soup {f['soup_mean']:.3f} vs best {f['best_mean']:.3f} "
+            f"({f['best_ingredient']})  LMC={'OK' if f['lmc_holds'] else 'FAIL'}"
+        )
+    print(f"uncond_gain   = {uncond_gain:+.4f}  (gate at +-{floor:.4f})")
+    print(f"VERDICT       = {verdict}")
+
+    has_sheet = save_contact_sheet(contact_rows, run_dir / "contact_sheet.png")
+    artifacts = [f"{f}_soup.safetensors" for f in ("base", "self")]
+    if has_sheet:
+        artifacts.append("contact_sheet.png")
+    write_result(
+        run_dir,
+        script=__file__,
+        args=args_cli,
+        metrics={
+            "arms": arm_stats,
+            "sigma_within": sigma_within,
+            "families": fam,
+            "uncond_gain": uncond_gain,
+            "gate_mult": args_cli.gate_mult,
+            "lmc_ok": lmc_ok,
+            "verdict": verdict,
+            "vseeds": vseeds,
+            "n_val_items": len(items),
+            "target_artist": args_cli.target_artist,
+        },
+        label=args_cli.label,
+        artifacts=artifacts,
+        device=acc.device,
+    )
+    print(f"\nWrote {run_dir / 'result.json'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/uncond_soup/soup.py
+++ b/bench/uncond_soup/soup.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Exact ΔW-average soup of plain-LoRA checkpoints via rank concatenation.
+
+Souping LoRAs *parameterwise* (averaging A's and B's) is wrong twice over:
+``avg(B) @ avg(A) != avg(B @ A)``, and with ``down_init="weight_svd"`` the
+randomized SVD's per-vector sign ambiguity means row-wise A averaging can
+actively cancel rows. So we soup at the ΔW level, which is invariant to any
+per-ingredient ``(A, B)`` reparameterization — and a weighted average of
+rank-r deltas is *exactly* representable as one rank-``sum(r_i)`` LoRA:
+
+    dW_soup = sum_i w_i * scale_i * up_i @ down_i'
+            = [w_1*scale_1*up_1 | w_2*scale_2*up_2 | ...] @ [down_1' ; down_2' ; ...]
+
+(block concatenation — no SVD truncation, no approximation), where
+``down_i' = down_i * inv_scale_i`` folds the persisted channel-scaling buffer
+back in so the soup applies to raw inputs (mirrors ``LoRAModule.get_weight``),
+and the soup's alpha is set to its rank (scale = 1). No ``inv_scale`` keys are
+carried, so the loaded soup module takes the raw-input path.
+
+Plain-LoRA checkpoints only (the lora.toml weight_svd / T-LoRA family —
+T-LoRA is training-only so its checkpoints are plain). Hydra / chimera /
+stacked-experts / ortho key shapes are refused loudly.
+
+Usage
+-----
+    # uniform soup
+    python bench/uncond_soup/soup.py \
+        --ckpts output/ckpt/a.safetensors output/ckpt/b.safetensors \
+        --out /tmp/soup.safetensors
+
+    # lambda=0.25 interpolation of a pair (LMC probe point)
+    python bench/uncond_soup/soup.py \
+        --ckpts a.safetensors b.safetensors --weights 0.75 0.25 --out mid.safetensors
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import torch
+
+# Suffixes a plain-LoRA checkpoint may carry per module. Anything else means a
+# non-plain variant (or a new format) — fail loudly rather than soup garbage.
+_ALLOWED_SUFFIXES = ("lora_down.weight", "lora_up.weight", "alpha", "inv_scale")
+# Non-module top-level keys we refuse (registers / routers / adapters change
+# inference behavior and cannot be averaged this way).
+_REFUSED_TOP_LEVEL = ("register_tokens",)
+
+
+def _split_key(key: str) -> tuple[str, str]:
+    """``lora_unet_..._q_proj.lora_down.weight`` -> (module, suffix)."""
+    head, _, _ = key.partition(".")
+    return head, key[len(head) + 1 :]
+
+
+def _group_modules(sd: dict, path: str) -> dict[str, dict[str, torch.Tensor]]:
+    modules: dict[str, dict[str, torch.Tensor]] = {}
+    for key, value in sd.items():
+        if key in _REFUSED_TOP_LEVEL or "." not in key:
+            raise ValueError(
+                f"{path}: key {key!r} is not a plain-LoRA module key — this "
+                "checkpoint carries state the ΔW soup cannot represent."
+            )
+        module, suffix = _split_key(key)
+        if suffix not in _ALLOWED_SUFFIXES:
+            raise ValueError(
+                f"{path}: unrecognized key suffix {suffix!r} on {module!r} — "
+                "only plain LoRA checkpoints (lora_down/lora_up/alpha/inv_scale) "
+                "can be souped; Hydra/chimera/stacked-experts/ortho are refused."
+            )
+        modules.setdefault(module, {})[suffix] = value
+    return modules
+
+
+def _effective_factors(
+    mod: dict[str, torch.Tensor], module: str, path: str
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """(down', up') in float32 such that ΔW = up' @ down' exactly.
+
+    Folds alpha/r scaling and the channel-scaling ``inv_scale`` buffer
+    (mirrors ``LoRAModule.get_weight``). Linear (2-D) only.
+    """
+    try:
+        down = mod["lora_down.weight"].to(torch.float32)
+        up = mod["lora_up.weight"].to(torch.float32)
+    except KeyError as exc:
+        raise ValueError(f"{path}: {module} is missing {exc} — truncated file?")
+    if down.dim() != 2 or up.dim() != 2:
+        raise ValueError(
+            f"{path}: {module} has non-Linear factors "
+            f"(down {tuple(down.shape)}, up {tuple(up.shape)}) — Conv LoRA is "
+            "not supported by the soup (the DiT LoRA family is Linear-only)."
+        )
+    rank = down.shape[0]
+    alpha = mod.get("alpha")
+    scale = (float(alpha) / rank) if alpha is not None else 1.0
+    inv_scale = mod.get("inv_scale")
+    if inv_scale is not None:
+        down = down * inv_scale.to(torch.float32).unsqueeze(0)
+    return down, up * scale
+
+
+def soup_state_dicts(
+    sds: list[dict],
+    weights: list[float] | None = None,
+    *,
+    paths: list[str] | None = None,
+    out_dtype: torch.dtype | None = None,
+) -> dict[str, torch.Tensor]:
+    """Build the exact rank-concatenated soup state dict.
+
+    ``weights`` default to uniform 1/N. They are used as-is (not normalized),
+    so ``[0.5, 0.5]`` on a pair is both the uniform soup and the lambda=0.5
+    LMC midpoint.
+    """
+    n = len(sds)
+    if n < 2:
+        raise ValueError("Need >= 2 ingredient checkpoints to soup.")
+    if weights is None:
+        weights = [1.0 / n] * n
+    if len(weights) != n:
+        raise ValueError(f"{len(weights)} weights for {n} checkpoints.")
+    paths = paths or [f"<sd {i}>" for i in range(n)]
+
+    grouped = [_group_modules(sd, p) for sd, p in zip(sds, paths)]
+    module_names = set(grouped[0])
+    for g, p in zip(grouped[1:], paths[1:]):
+        if set(g) != module_names:
+            missing = module_names.symmetric_difference(g)
+            raise ValueError(
+                f"Ingredient module sets differ ({p}): {sorted(missing)[:5]}... — "
+                "all ingredients must come from the same recipe."
+            )
+
+    if out_dtype is None:
+        out_dtype = sds[0][next(iter(sds[0]))].dtype
+
+    soup: dict[str, torch.Tensor] = {}
+    for module in sorted(module_names):
+        downs, ups = [], []
+        for g, w, p in zip(grouped, weights, paths):
+            down, up = _effective_factors(g[module], module, p)
+            downs.append(down)
+            ups.append(up * w)
+        soup_down = torch.cat(downs, dim=0)
+        soup_up = torch.cat(ups, dim=1)
+        rank = soup_down.shape[0]
+        soup[f"{module}.lora_down.weight"] = soup_down.to(out_dtype)
+        soup[f"{module}.lora_up.weight"] = soup_up.to(out_dtype)
+        # alpha = rank -> scale 1 (per-ingredient scales already folded into up).
+        soup[f"{module}.alpha"] = torch.tensor(float(rank), dtype=torch.float32)
+    return soup
+
+
+def build_soup_file(
+    ckpts: list[str], out: str, weights: list[float] | None = None
+) -> Path:
+    """Load ingredient .safetensors, soup, write ``out`` with updated metadata."""
+    from safetensors import safe_open
+    from safetensors.torch import load_file, save_file
+
+    sds = [load_file(c) for c in ckpts]
+    with safe_open(ckpts[0], framework="pt") as f:
+        metadata = dict(f.metadata() or {})
+
+    soup = soup_state_dicts(sds, weights, paths=list(ckpts))
+
+    ranks = {v.shape[0] for k, v in soup.items() if k.endswith(".lora_down.weight")}
+    rank_str = str(ranks.pop()) if len(ranks) == 1 else "Dynamic"
+    metadata["ss_network_dim"] = rank_str
+    metadata["ss_network_alpha"] = rank_str
+    metadata["ss_soup_ingredients"] = json.dumps(
+        {
+            "ckpts": [Path(c).name for c in ckpts],
+            "weights": weights or [1.0 / len(ckpts)] * len(ckpts),
+        }
+    )
+
+    out_path = Path(out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    save_file(soup, str(out_path), metadata=metadata)
+    return out_path
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--ckpts", nargs="+", required=True)
+    ap.add_argument(
+        "--weights",
+        nargs="+",
+        type=float,
+        default=None,
+        help="Per-ingredient weights (default uniform 1/N). Used as-is.",
+    )
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+    out = build_soup_file(args.ckpts, args.out, args.weights)
+    print(f"Wrote {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_uncond_soup.py
+++ b/tests/test_uncond_soup.py
@@ -1,0 +1,82 @@
+"""Invariant tests for the uncond-soup ΔW-exact soup builder.
+
+The load-bearing claim of bench/uncond_soup/soup.py: the rank-concatenated
+soup's delta equals the weighted average of the ingredients' deltas
+*exactly* (no SVD truncation), including alpha scaling and the channel-scaling
+``inv_scale`` fold — and it refuses non-plain checkpoints loudly.
+"""
+
+import pytest
+import torch
+
+from bench.uncond_soup.soup import soup_state_dicts
+
+
+def _delta(sd: dict, module: str) -> torch.Tensor:
+    """ΔW as LoRAModule.get_weight computes it (multiplier=1)."""
+    down = sd[f"{module}.lora_down.weight"].to(torch.float32)
+    up = sd[f"{module}.lora_up.weight"].to(torch.float32)
+    inv = sd.get(f"{module}.inv_scale")
+    if inv is not None:
+        down = down * inv.to(torch.float32).unsqueeze(0)
+    alpha = sd.get(f"{module}.alpha")
+    scale = float(alpha) / down.shape[0] if alpha is not None else 1.0
+    return (up @ down) * scale
+
+
+def _make_ingredient(seed: int, *, rank=4, din=16, dout=24, with_inv=False) -> dict:
+    g = torch.Generator().manual_seed(seed)
+    sd = {}
+    for module in ("lora_unet_a", "lora_unet_b"):
+        sd[f"{module}.lora_down.weight"] = torch.randn(rank, din, generator=g)
+        sd[f"{module}.lora_up.weight"] = torch.randn(dout, rank, generator=g)
+        sd[f"{module}.alpha"] = torch.tensor(2.0)
+        if with_inv:
+            sd[f"{module}.inv_scale"] = torch.rand(din, generator=g) + 0.5
+    return sd
+
+
+@pytest.mark.parametrize("with_inv", [False, True])
+def test_soup_delta_is_exact_weighted_average(with_inv):
+    sds = [_make_ingredient(s, with_inv=with_inv) for s in (0, 1, 2)]
+    weights = [0.5, 0.3, 0.2]
+    soup = soup_state_dicts(sds, weights, out_dtype=torch.float32)
+    for module in ("lora_unet_a", "lora_unet_b"):
+        expected = sum(w * _delta(sd, module) for w, sd in zip(weights, sds))
+        torch.testing.assert_close(_delta(soup, module), expected, rtol=1e-5, atol=1e-5)
+        # Soup itself is normalized: alpha == rank (scale 1), no inv_scale.
+        assert (
+            float(soup[f"{module}.alpha"])
+            == soup[f"{module}.lora_down.weight"].shape[0]
+        )
+        assert f"{module}.inv_scale" not in soup
+
+
+def test_uniform_default_and_midpoint():
+    sds = [_make_ingredient(s) for s in (0, 1)]
+    uniform = soup_state_dicts(sds, out_dtype=torch.float32)
+    midpoint = soup_state_dicts(sds, [0.5, 0.5], out_dtype=torch.float32)
+    for module in ("lora_unet_a", "lora_unet_b"):
+        torch.testing.assert_close(_delta(uniform, module), _delta(midpoint, module))
+
+
+def test_refuses_non_plain_keys():
+    sds = [_make_ingredient(s) for s in (0, 1)]
+    sds[1]["lora_unet_a.lora_up_weight"] = torch.randn(3, 24, 4)  # Hydra-style
+    with pytest.raises(ValueError, match="unrecognized key suffix"):
+        soup_state_dicts(sds)
+
+
+def test_refuses_register_tokens():
+    sds = [_make_ingredient(s) for s in (0, 1)]
+    sds[0]["register_tokens"] = torch.randn(4, 8)
+    with pytest.raises(ValueError, match="not a plain-LoRA module key"):
+        soup_state_dicts(sds)
+
+
+def test_refuses_mismatched_module_sets():
+    sds = [_make_ingredient(0), _make_ingredient(1)]
+    sds[1]["lora_unet_c.lora_down.weight"] = torch.randn(4, 16)
+    sds[1]["lora_unet_c.lora_up.weight"] = torch.randn(24, 4)
+    with pytest.raises(ValueError, match="module sets differ"):
+        soup_state_dicts(sds)


### PR DESCRIPTION
## What

New bench answering **"does soup-with-uncond really help?"** — the Self-Soupervision recipe (arXiv:2602.02890) mapped onto this pipeline, with the FID-lottery correction (arXiv:2606.20536) baked into every gate.

- **Pool bounded to 3 artists** (unlabeled via `caption_dropout_rate=1.0`; dropped rows get the T5("") sidecar `train.py` stages automatically).
- **Supervision = single artist**; two ingredient families share fine-tuning seeds (paired data order + FM noise), differing only in the uncond-inter-trained init (`--network_weights`).

## Files

- `bench/uncond_soup/launch.py` — emits the 7 training commands (never launches).
- `bench/uncond_soup/soup.py` — **exact** ΔW-average soup as one rank-N·r LoRA by block concatenation (folds alpha + channel-scaling `inv_scale`; refuses Hydra/chimera/ortho/register keys loudly; never averages A/B parameterwise — weight_svd sign ambiguity would cancel rows).
- `bench/uncond_soup/probe.py` — CMMD-scores ingredients, family soups, λ=0.5 midpoints (+ optional pool ckpt) against the target artist's held-out split. Reuses `bench/seed_lottery/probe.py` machinery wholesale.
- `tests/test_uncond_soup.py` — soup-delta exactness invariants (6 tests, pass).

## Gates

1. **LMC**: every pair midpoint ≤ endpoint mean + σ_within, else `LMC_FAILS` short-circuit.
2. **SOUP**: soup ≤ best ingredient + σ_within per family.
3. **UNCOND** (headline): `base_soup − self_soup > gate_mult·σ_within` → `UNCOND_HELPS`.

## Verified

- `pytest tests/test_uncond_soup.py` — 6 passed.
- `launch.py` smoke run emits correct commands (paired seeds, pool → `--network_weights` chain, probe invocation).
- `soup.py` end-to-end on synthetic safetensors: rank 8 soup from 2×rank-4, three-axis stamps preserved, provenance metadata recorded.
- `probe.py --help` exercises the full import chain (train module + seed_lottery reuse).
- Not run: the actual 7 training runs + GPU probe (that's the bench's job).

## Caveat (in README)

Not compute-matched — the self family gets the pool pre-train for free. A pass licenses a Phase 1 with an equal-budget control, not a shipping decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)