### PR TITLE
Proposals: trajectory-resolved latent statistics + DPCache DP-planned Spectrum schedule

### DIFF
--- a/docs/proposal/dpcache_dp_schedule.md
+++ b/docs/proposal/dpcache_dp_schedule.md
@@ -1,0 +1,226 @@
+# DPCache — DP-planned global skip schedule as a third Spectrum schedule mode
+
+Status: **DRAFT 2026-07-23 — nothing built. Phase 0 (offline paper-check on
+existing counterfactual data) gates Phase 1 (planner + `--spectrum_schedule dp`);
+Phase 2 (matched-compute A/B vs `window`/`sea`) is the ship gate; the hybrid
+dp+sea mode is explicitly speculative and gated on Phase 2 evidence.**
+
+Paper: DPCache (Cui et al., Alibaba, arXiv:2602.22654v2) — training-free
+diffusion acceleration that plans the cache schedule *globally*: calibrate a few
+full-step runs, build a **Path-Aware Cost Tensor** `C[i,j,k]` (cumulative L1
+feature-prediction error of skipping from step `j` to `k` given preceding key
+step `i`), then dynamic-programming-select the optimal `K` key timesteps for a
+fixed compute budget. Full forwards only at key steps; skipped steps get
+forecast features. Claims 4.87× on FLUX with better quality than
+TeaCache/TaylorSeer/SpeCa and much higher fidelity-to-baseline (PSNR +2.4,
+LPIPS −0.11).
+
+## Premise
+
+Spectrum's when-to-skip decision now has two modes (`docs/inference/spectrum.md`):
+the content-blind **growing window** (default) and the content-adaptive **SEA
+trigger** (`--spectrum_schedule sea`, grafted from SeaCache —
+`docs/findings/seacache_sea_decision_metric.md`). Both are *local* policies: the
+window is a fixed cadence, SEA is a greedy accumulate-and-fire threshold. Neither
+sees the global structure of the trajectory, and the SEA finding closed with a
+concrete symptom of that blindness:
+
+> the σ<0.45 tail carries ≈0% of SEA-weighted skip-cost … yet the blind schedule
+> force-computes the last 3 steps — a concrete reallocation the adaptive trigger
+> could exploit.
+
+DPCache is precisely the reallocation machine: given a compute budget `K`, the DP
+finds the provably-optimal *placement* of the `K` real forwards under the cost
+model — it will abandon the dead tail and spend those forwards on critical
+transitions, something neither a growing window nor a greedy threshold can do
+(the threshold only reacts once cost has already accumulated; it cannot *move*
+a forward earlier).
+
+The integration follows the exact pattern the SEA graft validated: **swap only
+the when-to-skip decision, keep everything else** — Chebyshev forecasting, the
+per-step head recompute (`t_embedder → final_layer → unpatchify`), warmup/stop
+forcing. DPCache's reuse is forecast-style (each skipped step gets a fresh,
+distinct predicted feature, not a frozen output) and the paper states the
+framework is predictor-agnostic, so Spectrum's forecaster slots in directly.
+Because the per-step `noise_pred` reconstruction still runs every step, the
+sampler-boundary plug-ins (SMC-CFG, mod-guidance) compose unchanged — the same
+composition argument already on record for SEA.
+
+Operational side-benefit: the schedule is computed **once, offline** (the DP is
+`O(KT²)`, negligible), keyed on schedule geometry exactly like
+`output/spectrum_sea_delta.json`. It *replaces* SEA's auto-δ matched-compute
+binary search with something cleaner — specify the budget `K` directly, get the
+optimal placement for it. Zero per-step overhead, fully deterministic,
+compile-friendly (the skip pattern is known before step 0).
+
+## The open question this proposal actually decides
+
+DP-planned (global, content-blind) vs SEA (local, content-adaptive) is a genuine
+empirical toss-up on Anima, and our own data cuts both ways:
+
+- **For DP**: the paper beats the locally-adaptive methods (TeaCache, SpeCa) on
+  exactly the fidelity metrics where global planning should win, and its
+  calibration ablation shows the schedule is content-agnostic (1 sample ≈ 11
+  samples ≈ different prompt source → identical schedule).
+- **For SEA**: Phase 1 of the SeaCache eval proved there IS real per-prompt
+  signal on Anima — step-stratified, SEA-filtered input distance predicts *which
+  prompt* is costlier to skip at a given step (ρ +0.51). A fixed global schedule
+  cannot capture that, by construction.
+
+These are orthogonal axes (step *placement* vs prompt *adaptivity*), so the
+ceiling is probably a hybrid — but the cheap, decision-grade question is whether
+globally-optimal placement alone beats the shipped modes at matched compute.
+
+## Prior art in-tree (why this is cheap)
+
+- **The decision-vs-reuse split is already established.** The SEA graft
+  (`networks/spectrum.py` + `networks/spectrum_sea.py`) proved the scheduler is
+  a clean seam: `spectrum_denoise` picks refresh-vs-forecast per step behind one
+  predicate (`schedule == "sea"` branch, ~L303). A `dp` mode is a precomputed
+  boolean mask consulted at the same seam — strictly simpler than SEA (no
+  per-step FFT, no accumulator state).
+- **The cost-measurement harness already exists.**
+  `_archive/bench/spectrum_sea/phase1_counterfactual.py` computes the **true
+  counterfactual skip-cost** — actually cache the step (forecast both branches,
+  run only the head), CFG-combine, measure x̂₀ deviation vs full compute. That
+  is a per-step slice of exactly the quantity PACT wants; extending it from
+  single-step skips to `(i, j, k)` segments is the calibration stage.
+- **The evaluation discipline is already written down.** Step-stratification
+  (detrend the shared σ-envelope before correlating), sanity-check estimators on
+  monotone-only synthetic input, matched-compute comparison, eyeball/CMMD ship
+  gate — all from `seacache_sea_decision_metric.md`. This proposal inherits
+  them wholesale.
+- **The prior-inversion record says: verify, don't trust.** CTCal and the
+  spectral-fraction metric both inverted published priors on Anima
+  (`ctcal_premise_inverted_on_anima.md`, `spectral_fraction_metric_inverts.md`).
+  Two of DPCache's premises get re-verified here rather than assumed
+  (open-loop calibration fidelity, content-agnosticism — see Phase 1).
+
+## Known weaknesses of the paper (and how the phases address them)
+
+1. **PACT is open-loop.** Calibration measures skip errors along the *undrifted*
+   full-step trajectory; at inference, forecast errors feed back into `x_t`.
+   The cumulative-L1 segments and one-predecessor conditioning only partially
+   model closed-loop drift. → Phase 1 builds PACT from the **true
+   counterfactual** harness instead of the paper's open-loop replay, and
+   Phase 0 measures how much the two disagree before any planner code lands.
+2. **Content-agnosticism is a claim about FLUX/HunyuanVideo, not Anima** — and
+   our SEA result already shows per-prompt cost variance exists here. → Phase 1
+   re-runs the paper's calibration ablation on Anima (does the planned schedule
+   change across disjoint calibration prompt sets?). If schedules diverge,
+   content-agnostic planning is out and only the hybrid survives.
+3. **Less headroom at Anima's step counts.** The paper plans `K` out of `T=50`;
+   Anima typically samples 24–30 steps, so the planner has fewer degrees of
+   freedom and the margin over the window shrinks. → Phase 0 quantifies the
+   margin on paper before anything is built.
+4. **"Beats the full-step baseline" (+0.028 ImageReward)** is reward-metric
+   noise/bias, not free quality. Ignored; the fidelity numbers (PSNR/LPIPS) are
+   the credible result.
+
+## Phases
+
+### Phase 0 — offline paper-check (no inference-path code)
+
+Rebuild the cost structure from recorded trajectories and run the DP on paper.
+`bench/spectrum_dp/run_bench.py` (shares `bench/_common.py`, standard
+`result.json` envelope):
+
+1. Record full-step trajectories (features + `x_t`) for the SEA bench's prompt
+   set at the shipped geometry (24–30 steps, CFG, 1024²).
+2. Build **open-loop PACT** exactly per the paper (Chebyshev-forecast segment
+   `j→k` from features at `i, j`; cumulative L1 over skipped steps, final-layer
+   features only — `T≈28` makes the tensor trivially small).
+3. DP-select schedules for `K` matched to the window's and SEA's realized
+   post-warmup refresh counts (the matched-compute discipline from the SEA
+   eval).
+4. Score all three schedules under the **true single-step counterfactual cost**
+   already measured by `phase1_counterfactual.py` (re-run, not reused — same
+   harness, current checkpoint).
+
+**Gate**: DP's planned schedule must beat the window's realized schedule on
+summed counterfactual cost at matched `K`, and at least tie SEA's. If it can't
+win on its own cost model's home turf, stop — nothing ships, total cost is one
+bench.
+
+Deliverable also includes the **tail check**: does the planner reallocate the
+σ<0.45 force-computed steps as the SEA finding predicted? (If yes, that's the
+mechanism; if it wins *without* touching the tail, the win is coming from
+somewhere unmodeled — investigate before Phase 1.)
+
+### Phase 1 — closed-loop PACT + the planner + `--spectrum_schedule dp`
+
+Only on a Phase-0 pass:
+
+- **Closed-loop PACT**: extend the counterfactual harness from single-step
+  skips to `(i, j, k)` segments — actually forecast across the segment with the
+  drifted `x_t` feeding back, measure cumulative x̂₀ deviation. Compare against
+  the open-loop tensor (this is the paper-weakness-1 measurement). Use
+  whichever the Phase-0 scoring says is more faithful.
+- **Content-agnosticism ablation on Anima**: build PACT from disjoint
+  calibration prompt sets (n=1 / n=5 / n=11, anime prompts vs DrawBench-style);
+  compare planned schedules. Identical → one cached schedule per geometry, like
+  the paper. Divergent → content-agnostic planning is falsified on Anima
+  (recorded as a finding either way).
+- **Planner + integration**: `networks/spectrum_dp.py` (PACT build + DP +
+  schedule cache, mirroring `spectrum_sea.py`'s role), a `dp` arm in
+  `spectrum_denoise`'s decision seam, schedule cached to
+  `output/spectrum_dp_schedule.json` keyed on the same geometry tuple as the
+  SEA δ (steps / warmup / stop / K / cfg / sampler / H×W — not the prompt).
+  Calibration runs route through `make gen` (daemon) like every other bench.
+- **Invariants** (pinned by tests, per the Tier-1.5 contract):
+  - `dp` mode changes *only* which steps refresh — forecast + head recompute
+    still run every step (the SMC-CFG/mod-guidance composition invariant, same
+    test shape as SEA's).
+  - Warmup and stop-caching forcing are respected: `M ≥ warmup` initial steps
+    and the final forced steps are constraints on the DP, not overridable by it
+    (relaxing the tail forcing is a *separate, explicit* knob — it is the
+    experiment, not a silent default).
+  - Missing/stale schedule cache → hard fall back to `window`, never a partial
+    schedule.
+
+### Phase 2 — matched-compute A/B (ship gate)
+
+Three-arm comparison at identical realized refresh counts: `window` vs `sea`
+vs `dp`, over the SEA eval's prompt grid. Fidelity-to-baseline (x̂₀ RMSE / CMMD
+vs the unaccelerated run) as primary, eyeball A/B as the gate — the same
+protocol that shipped (and nearly didn't hold back) the SEA node mirror. `dp`
+ships as opt-in only on a win or clear tie-with-simplification; `window` stays
+the default regardless.
+
+### Phase 3 — hybrid dp+sea (speculative, gated on Phase 2)
+
+Only if Phase 2 shows `dp` and `sea` winning on *different* prompts/steps
+(i.e. the orthogonality thesis holds empirically): DP-planned baseline schedule
++ SEA-triggered *extra* refreshes on top (never removals — the plan is the
+floor, the trigger only adds). Budget accounting and the δ/K interaction get
+designed then, not now.
+
+## Non-goals / scope guards
+
+- **Not a Spectrum replacement and not a new reuse policy.** Chebyshev
+  forecasting, head recompute, cond/uncond-separate forecasters are untouched.
+  Adopting DPCache's TaylorSeer predictor or final-layer-only caching is out of
+  scope (Spectrum's single-hook capture already has the same memory profile).
+- **No per-prompt planning.** If content-agnosticism fails on Anima, the answer
+  is the Phase-3 hybrid, not running calibration per prompt at inference time.
+- **No training-loop involvement, no config-default changes.** `window` remains
+  the default schedule; `dp` is opt-in behind the existing
+  `--spectrum_schedule` flag.
+- The ComfyUI node mirror is deliberately deferred until the library mode
+  survives Phase 2 (the SEA precedent: library first, node after the gate).
+
+## Falsifiers (cheap exits)
+
+1. **Phase 0**: DP at matched `K` doesn't beat the window's realized schedule on
+   true counterfactual cost → global planning adds nothing over a monotone
+   cadence at Anima's step counts → stop, archive the bench, one finding doc.
+2. **Phase 1**: open-loop and closed-loop PACT rank schedules differently *and*
+   the closed-loop planner loses its Phase-0 margin → the paper's calibration
+   premise doesn't survive feedback drift on Anima → stop (this would be the
+   third prior-inversion on record).
+3. **Phase 1**: planned schedules diverge across calibration sets → content-
+   agnosticism falsified on Anima → skip Phase 2 for standalone `dp`, re-scope
+   to the hybrid or stop.
+4. **Phase 2**: quality regression vs `sea` at matched compute → SEA's
+   per-prompt adaptivity beats global placement here → keep `sea`, archive `dp`
+   with the A/B data.

--- a/docs/proposal/traj_latent_stats.md
+++ b/docs/proposal/traj_latent_stats.md
@@ -1,0 +1,206 @@
+# Trajectory-resolved latent statistics — effective token usage measured *during* generation
+
+Status: **DRAFT 2026-07-23 — nothing built. Phase 0 (passive recorder) gates
+Phase 1 (atlas); Phase 2 (intactness gauge) is the actual product; Phase 3
+(interventions) is explicitly speculative and gated on Phase 1/2 evidence.**
+
+## Premise
+
+The Anima DiT works in the Qwen Image VAE latent space (`z_dim = 16`,
+per-channel `latents_mean` / `latents_std` shipped in the model config). The
+anime domain is latent-sparse: flat cel shading, line art, and uniform
+backgrounds mean most spatial tokens of a *finished* image carry near-zero
+unique information under quantization. Static corpus statistics (quantize the
+cached `.npz` latents, measure per-token / per-channel entropy) would confirm
+that — but they are **reconstruction** statistics of clean images. They say
+nothing about *when* along the σ trajectory each token's information
+materializes, and the one intervention this repo already tried on the strength
+of redundancy signals — the deferred-foveated merge — died precisely because
+its damage was invisible to final-result framing until benched hard:
+
+> the periphery soft blur is **constitutive** (P4t: no tail treatment recovers
+> it) — `docs/inference/foveated.md`, archived 2026-07-03.
+
+A region denoised at reduced token count never receives its high-frequency
+detail. The failure lives in the **process**, not the endpoint: final-image
+metrics on the fovea looked fine, the periphery *trace* was what flatlined.
+
+This proposal inverts the order of operations. Before proposing any new
+efficiency intervention, build the measurement layer:
+
+1. **Measure statistics while generation runs** — per-step, per-token,
+   per-channel — using signals the loop already computes for free.
+2. Derive an **effective token usage profile** `E(σ)`: at each noise level,
+   what fraction of tokens is still actively receiving information?
+3. Turn the same traces into a **trajectory-intactness gauge**: a candidate
+   intervention must keep the *whole generation process* statistically intact
+   relative to baseline, not merely score well on the final image. "Intact on
+   overall generation process, not only on final result."
+
+Everything in Phases 0–2 is observability. No generation behavior changes.
+
+## Prior art in-tree (why this is cheap)
+
+- **Free per-step signals already exist.** The foveated runner accumulated
+  `cfgdelta` (per-cell |v_cond − v_uncond|) and `x0var` (x̂₀ Laplacian energy)
+  during early steps with "zero extra models, zero extra forwards"
+  (`docs/inference/foveated.md` §Mechanism-2, `networks/foveated.py`). The
+  recorder generalizes exactly this accumulation — full-trajectory, dumped to
+  disk, no mask built, nothing acted on.
+- **Process-level probes are an established pattern.** The main loop already
+  carries capability probes that manipulate the *trajectory* to answer
+  process questions: `ANIMA_TEXT_KNOCKOUT_SIGMA`, `ANIMA_FREEZE_GUIDANCE_SIGMA`
+  (`library/inference/generation.py` ~L897–913). This proposal adds the
+  passive complement: observe the trajectory instead of perturbing it.
+- **Channel calibration precedent.** `docs/optimizations/channel_scaling.md` /
+  `_archive/bench/channel_stats/channel_dominance_analysis.md` did the
+  per-channel statistics program for DiT *activations*. This is the analog for
+  the VAE latent trajectory.
+- **The gauge has a validation target on day one.** The archived foveation
+  runner still works (off by default). A trajectory gauge that cannot flag
+  foveation's periphery flatline — a *known* constitutive process defect —
+  is falsified immediately.
+
+## The statistics
+
+All computed on `x̂₀ = latents − σ·v` (the per-step denoised estimate, already
+formed at `generation.py` L510/L1067 — flow-matching, so this is one FMA we
+get for free), normalized per channel with the VAE's `latents_mean` /
+`latents_std` so "a bit" means the same thing in every channel. "Token" =
+16-px patch cell = a `2×2` latent-pixel cell aggregated to the DiT patch grid,
+so maps are directly comparable to attention/token-count reasoning.
+
+Per step `i` (σ = `sigmas[i]`), per token `p`:
+
+| trace | definition | what it answers |
+|---|---|---|
+| **code(p, i)** | k-bit uniform quantization code of x̂₀ (default k=4/channel, knob) | the quantized-VAE view: which discrete cell the token estimate is in |
+| **commit(p)** | last step where `code(p, ·)` changed | when did this token's content lock? |
+| **activity(p, i)** | ‖x̂₀(p, i) − x̂₀(p, i−1)‖ | is information still flowing into this token? |
+| **hf(p, i)** | Laplacian energy of x̂₀ in the token's neighborhood | foveation's x0var, kept for continuity — the trace that flatlined |
+| **guide(p, i)** | ‖v_cond − v_uncond‖ per token (CFG runs only) | foveation's cfgdelta — where the prompt is steering |
+| **cbits(c, i)** | entropy of channel c's code histogram over all tokens | per-channel information ramp — which of the 16 channels the anime domain actually uses, and when |
+
+Derived scalars:
+
+- **E(σ)** — effective token usage: fraction of tokens with
+  `activity(p, i) > τ` (τ from the noise floor at σ→0). The headline curve.
+- **commit-CDF** — distribution of `commit(p)` over σ. If 60 % of tokens have
+  committed by σ = 0.4 on the anime corpus, that is the quantified headroom
+  for *any* late-step token intervention — and if the CDF is flat, the whole
+  efficiency thesis dies cheaply, in Phase 1, without shipping anything.
+
+Storage: one `.npz` sidecar per generation (fp16 maps + a small JSON header:
+seed, prompt hash, resolution, sampler, step count, k). At 28 steps × ~4 k
+tokens × 6 traces ≈ a few MB — fine for bench runs, which is the only
+intended producer.
+
+## Phases
+
+### Phase 0 — passive recorder (`--traj_stats`)
+
+A small observer class, `library/inference/traj_stats.py`, threaded through
+the denoise loops the same way `smc_cfg` is (constructed in the engine from
+`args`, `None` when off):
+
+- `record(i, sigma, latents, noise_pred, uncond_noise_pred=None)` called once
+  per step, after the CFG combine, before the sampler step.
+- Hook sites: `generate_body` main loop (`library/inference/generation.py`
+  ~L916), the tiled loop (~L393), and `networks/spectrum.py::spectrum_denoise`
+  (so Spectrum-composed runs are measurable too — the gauge's "known-good"
+  arm needs this).
+- **Invariants** (each pinned by a test, per the Tier-1.5 contract):
+  - Recorder on/off produces **bit-identical** latents (pure observation; all
+    stats math on `.float()` *copies*, never in-place, and never feeding back).
+  - 5D discipline: in-loop latents are `(B, C, 1, H, W)` — the recorder
+    squeezes **dim 2 explicitly** (never bare `squeeze()`; see the CLAUDE.md
+    dim-2 invariant) and asserts 4D before any FFT/Laplacian helper.
+  - Off by default; zero allocations when off (`None` short-circuit, same as
+    the other plug-ins).
+- Overhead budget: < 2 % step time at 1024² (quantize + diff + one 3×3 conv,
+  all on-GPU, dumped async at end). Measured in the Phase 0 bench.
+
+### Phase 1 — the atlas (anime-domain trajectory statistics)
+
+`bench/traj_stats/run_bench.py` (shares `bench/_common.py`, drops the
+standard `result.json` envelope into `bench/traj_stats/results/`):
+
+1. **Generation arm**: seed × prompt grid over anime prompts via the recorder
+   (routed through `make gen` so it queues behind training instead of
+   OOM-colliding). Aggregate `E(σ)`, commit-CDF, `cbits(c, ·)`.
+2. **Real-image arm**: DirectEdit inversion
+   (`library/inference/editing/directedit.py`) replays a *real* cached-corpus
+   image as a trajectory — recorder on the inversion pass gives the same
+   traces for ground-truth anime images, tying the during-generation
+   statistics back to the static corpus-cache statistics (which this bench
+   also computes from `post_image_dataset/lora/*.npz` as the zero-cost
+   baseline column).
+3. Deliverable: a short report answering (a) how front-loaded is token
+   commitment in this domain, (b) which channels carry it, (c) does generation
+   match inversion (if not, generated trajectories are off-manifold and the
+   corpus stats don't transfer — important negative result on its own).
+
+### Phase 2 — the trajectory-intactness gauge
+
+The product. For a candidate intervention X and a fixed (prompt, seed, steps):
+
+    D(X) = per-σ divergence profile between X's traces and baseline's traces
+           — token-wise x̂₀ RMSE(σ), |E_X(σ) − E_base(σ)|, hf-trace delta,
+           commit-CDF shift — reported as a *curve*, not one scalar.
+
+Calibration, both directions:
+
+- **Known-bad**: the archived foveation runner (`--fovea_sigma_c 0.75`). The
+  gauge must show the periphery `hf` trace flatlining below σ_c and a
+  commit-CDF hole — i.e. it must rediscover P4t from traces alone, *without
+  looking at the final image*. This is the acceptance test.
+- **Known-good**: Spectrum and SMC-CFG composes (shipped, quality-neutral by
+  their own benches) must show small, structureless D. If the gauge flags
+  shipped-good methods, τ / normalization get re-tuned before anyone uses it.
+
+Output: `bench/traj_stats/gauge.py --baseline <dir> --candidate <dir>` →
+verdict bands (calibrated in this phase, provisional: intact · perturbed ·
+process-broken), riding the same `result.json` envelope.
+
+### Phase 3 — interventions (gated, speculative)
+
+Only if Phase 1 shows exploitable structure (front-loaded commit-CDF, skewed
+`cbits`), ranked by the Phase 2 gauge before any quality bench is spent:
+
+- **Entropy-aware tier routing** (training-side, safest): feed per-image
+  latent entropy into `choose_edge` (`library/datasets/buckets.py` L116) so
+  flat cel-style images train a tier down. No inference-time process risk at
+  all — the gauge is irrelevant here, corpus stats from Phase 1 suffice.
+- **Committed-token compute reuse** (inference-side): below a σ threshold,
+  reuse the previous step's velocity for tokens whose code has been stable
+  for m steps (a delta-token / cache-skip scheme — tokens keep their
+  *identity and resolution*, unlike merging; staleness is bounded and
+  refreshable, unlike foveation's constitutive pooling). Gauge-gated.
+- **σ-scheduled channel truncation**: if `cbits` shows late-σ channels idle,
+  drop them from the stats/guidance path — *measurement first*.
+
+Explicitly **not** proposed: re-running token *merging* with better selection.
+P3/P4t closed that line — the defect was the mechanism (reduced-resolution
+denoising), not the mask, and a better redundancy prior does not change that.
+
+## Non-goals / scope guards
+
+- Phases 0–2 never change a generated image. The recorder is falsifiable on
+  bit-exactness and ships with that test.
+- No new models, no extra forwards, no training-loop involvement (the
+  training-side Phase 3 item consumes Phase 1 *outputs*, not the recorder).
+- `k`, τ, and verdict bands are bench-calibrated knobs, not shipped defaults —
+  nothing here touches `configs/base.toml`.
+- Tiled path support is best-effort in Phase 0 (record post-blend only);
+  per-tile traces are out of scope.
+
+## Falsifiers (cheap exits)
+
+1. Phase 1 commit-CDF ≈ uniform in σ → no late-step headroom → Phase 3
+   inference items die; only tier routing survives (and only if the *static*
+   corpus stats are skewed).
+2. Generation-arm vs inversion-arm traces disagree structurally → corpus
+   statistics don't transfer to generation → restrict all claims to img2img /
+   editing paths.
+3. Gauge can't separate foveation (known-bad) from Spectrum (known-good) →
+   the trace set is insufficient; stop before anyone trusts it.


### PR DESCRIPTION
## Summary

Two doc-only proposals; no code paths touched.

### 1. `docs/proposal/traj_latent_stats.md` — trajectory-resolved latent statistics

Measure Qwen-VAE latent statistics **while generation runs** (per-step, per-token, per-channel), instead of only on final images or cached corpus latents.

Motivation: the anime domain is latent-sparse, but static quantized-VAE statistics are reconstruction statistics of clean images — they say nothing about *when* each token's information materializes along the σ trajectory. And the archived foveated-merge line showed that process damage (periphery HF trace flatlining) can be invisible to final-result framing. So: build the measurement layer first, and make "intact on the overall generation process, not only on the final result" the acceptance criterion for any future efficiency intervention.

- **Statistics**: all derived from signals the denoise loop already computes for free (x̂₀, cond/uncond velocity delta) — quantization codes, token commit step, activity, HF energy, per-channel information ramp; headline curves are effective token usage `E(σ)` and the commit-CDF.
- **Phase 0** — passive `--traj_stats` recorder at the sampler boundary, pinned bit-exact-when-on and zero-cost-when-off by invariant tests.
- **Phase 1** — anime-domain atlas bench (generation arm + DirectEdit-inversion arm over real corpus images).
- **Phase 2** — trajectory-intactness gauge, calibrated with the archived foveation runner as known-bad (must rediscover P4t from traces alone) and Spectrum/SMC-CFG as known-good.
- **Phase 3** (gated, speculative) — entropy-aware tier routing, committed-token compute reuse. Token *merging* is explicitly not re-proposed.

### 2. `docs/proposal/dpcache_dp_schedule.md` — DPCache DP-planned skip schedule for Spectrum

Evaluates **DPCache** (Cui et al., Alibaba, arXiv:2602.22654) on Anima, scoped as a third `--spectrum_schedule` mode (`dp`) rather than a Spectrum replacement. DPCache formulates cache scheduling as global path planning: calibrate a few full-step runs, build a Path-Aware Cost Tensor of segment skip-costs, and DP-select the optimal K key timesteps for a fixed compute budget.

The proposal grafts only the *when-to-skip* decision onto Spectrum's scheduler seam — the same surgery that shipped the SEA trigger — keeping Chebyshev forecasting and the per-step head recompute so SMC-CFG / mod-guidance composition is untouched.

- **Directly targets the open item** from `docs/findings/seacache_sea_decision_metric.md`: the σ<0.45 tail carries ≈0% of skip-cost yet the blind schedule force-computes it — a DP planner is the reallocation machine for exactly that.
- **Phase 0 is a pure offline paper-check** (no inference-path code): rebuild the cost tensor from the existing true-counterfactual harness and race the planned schedule against `window`/`sea` at matched refresh counts. Hard gate — if DP can't win there, nothing gets built.
- **Re-verifies rather than trusts** the paper's two weakest premises on Anima (open-loop calibration fidelity, content-agnostic schedules), per the repo's prior-inversion record.
- Phase 2 matched-compute A/B is the ship gate; a hybrid dp+sea mode is speculative and gated on Phase 2 evidence. `window` stays the default throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QG7zBdQGW1ht1xerxrnLuH