### PR TITLE
Define rating tags as Anima's band: safe / sensitive / nsfw / explicit

### DIFF
--- a/custom_nodes/comfyui-anima-tagger/_vendor/library/captioning/anima_tagger.py
+++ b/custom_nodes/comfyui-anima-tagger/_vendor/library/captioning/anima_tagger.py
@@ -164,8 +164,16 @@ TAG_TYPE_NAMES: Dict[int, str] = {
     6: "deprecated",
 }
 
-# 3-class rating set (post-``questionable→sensitive`` collapse).
-RATINGS: Tuple[str, ...] = ("general", "sensitive", "explicit")
+# Anima's 4-class rating set, in canonical class-index order (least → most
+# restrictive). Same members as ``library.captioning.taxonomy.CAPTION_RATINGS``
+# — that module holds the unordered set + the legacy booru aliases
+# (``general``→``safe``, ``questionable``→``nsfw``); the order lives here
+# because it's the rating head's class index. Do not reorder without rebuilding
+# vocab: ``vocab.json`` snapshots this list and ``dataset.json`` stores indices
+# into it. Existing checkpoints are unaffected — ``AnimaTagger`` reads
+# ``vocab["ratings"]`` from the checkpoint, and ``n_ratings`` comes from the
+# manifest, so a 3-class checkpoint keeps loading and predicting its own labels.
+RATINGS: Tuple[str, ...] = ("safe", "sensitive", "nsfw", "explicit")
 
 # 8-class people-count bucket from parsed count tags
 # (``scripts.anima_tagger.constants.classify_people``); dedicated softmax head.

--- a/custom_nodes/comfyui-anima-tagger/_vendor/library/captioning/anima_tagger_model.py
+++ b/custom_nodes/comfyui-anima-tagger/_vendor/library/captioning/anima_tagger_model.py
@@ -59,6 +59,9 @@ class AnimaTaggerConfig:
     d_in: int  # PE-Core token dim (d_enc), not the pool-output dim.
     n_tags: int
     d_in_aux: int  # PE-Spatial token dim — always required.
+    # Back-compat default, NOT the canonical band size: pre-rename checkpoints
+    # were 3-class (general/sensitive/explicit). Anima's band is 4-class
+    # (``anima_tagger.RATINGS``) and every trainer passes it from the manifest.
     n_ratings: int = 3
     # 0 = no people head; trainer sets this from the manifest when in use.
     n_people_counts: int = 0

--- a/docs/experimental/anima_tagger.md
+++ b/docs/experimental/anima_tagger.md
@@ -32,7 +32,7 @@ PIL image → PIL LANCZOS-resize to PE-Core bucket size
          → LayerNorm + Linear(1024, 1024) + GELU + Dropout
          ────────────────────────────────────────────────── shared trunk_h
          ├→ Linear(1024, n_tags)       → tag_logits     ──── multi-label head
-         └→ Linear(1024, 3)            → rating_logits  ──── 3-class rating head
+         └→ Linear(1024, n_ratings)    → rating_logits  ──── rating head
 
 Per-tag F1-calibrated threshold sweep at the end of training picks the
 inference threshold for each output dimension. Tags belonging to a
@@ -46,6 +46,23 @@ delta over the trailing PE-Core blocks; alpha/rank/layers configurable.
 
 The shipped checkpoint runs the frozen path (`pe_lora: false`), trained
 for 100 epochs at `lr=2e-4`, `batch_size=64`, `lambda_rating=0.1`.
+
+### Rating band
+
+Anima's rating band is 4-class — `safe, sensitive, nsfw, explicit`.
+`library.captioning.anima_tagger.RATINGS` fixes the class *order* (it's the
+rating head's class index); `library.captioning.taxonomy.CAPTION_RATINGS` is
+the unordered set the caption-side consumers test against. Danbooru's own
+literals are accepted as aliases and folded onto the band at vocab-build time
+(`general`→`safe`, `questionable`→`nsfw`), so a raw booru caption still
+classifies as a rating instead of falling through to the `general`
+*category*.
+
+The rename does not invalidate checkpoints: `AnimaTagger` reads
+`vocab["ratings"]` from the checkpoint and `n_ratings` flows from the
+manifest, so the shipped 3-class checkpoint keeps loading and predicting its
+own labels. Rebuilding vocab against the 4-class band widens the head — that
+is a retrain.
 
 ### Why a shared trunk for both heads
 
@@ -352,8 +369,8 @@ scaffolding, or `Save Text File` for LoRA dataset pre-fill.
 ## Known limitations
 
 1. **Rating-class imbalance.** Train-corpus rating mix is ~67% explicit
-   / ~32% sensitive / ~0.6% general. Class-weighted CE compensates
-   partially. If `general`-rating accuracy matters downstream, oversample
+   / ~32% sensitive / ~0.6% safe. Class-weighted CE compensates
+   partially. If `safe`-rating accuracy matters downstream, oversample
    at training time.
 2. **Per-tag positives are thin for the long tail.** At `min_freq=5`
    each long-tail tag has 5–20 positives; calibrated thresholds for those

--- a/library/captioning/anima_tagger.py
+++ b/library/captioning/anima_tagger.py
@@ -164,8 +164,16 @@ TAG_TYPE_NAMES: Dict[int, str] = {
     6: "deprecated",
 }
 
-# 3-class rating set (post-``questionable→sensitive`` collapse).
-RATINGS: Tuple[str, ...] = ("general", "sensitive", "explicit")
+# Anima's 4-class rating set, in canonical class-index order (least → most
+# restrictive). Same members as ``library.captioning.taxonomy.CAPTION_RATINGS``
+# — that module holds the unordered set + the legacy booru aliases
+# (``general``→``safe``, ``questionable``→``nsfw``); the order lives here
+# because it's the rating head's class index. Do not reorder without rebuilding
+# vocab: ``vocab.json`` snapshots this list and ``dataset.json`` stores indices
+# into it. Existing checkpoints are unaffected — ``AnimaTagger`` reads
+# ``vocab["ratings"]`` from the checkpoint, and ``n_ratings`` comes from the
+# manifest, so a 3-class checkpoint keeps loading and predicting its own labels.
+RATINGS: Tuple[str, ...] = ("safe", "sensitive", "nsfw", "explicit")
 
 # 8-class people-count bucket from parsed count tags
 # (``scripts.anima_tagger.constants.classify_people``); dedicated softmax head.

--- a/library/captioning/anima_tagger_model.py
+++ b/library/captioning/anima_tagger_model.py
@@ -59,6 +59,9 @@ class AnimaTaggerConfig:
     d_in: int  # PE-Core token dim (d_enc), not the pool-output dim.
     n_tags: int
     d_in_aux: int  # PE-Spatial token dim — always required.
+    # Back-compat default, NOT the canonical band size: pre-rename checkpoints
+    # were 3-class (general/sensitive/explicit). Anima's band is 4-class
+    # (``anima_tagger.RATINGS``) and every trainer passes it from the manifest.
     n_ratings: int = 3
     # 0 = no people head; trainer sets this from the manifest when in use.
     n_people_counts: int = 0

--- a/library/captioning/correction.py
+++ b/library/captioning/correction.py
@@ -13,7 +13,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
-from library.captioning.taxonomy import CAPTION_RATINGS, is_artist_tag, is_count_tag
+from library.captioning.taxonomy import (
+    canonical_rating,
+    is_artist_tag,
+    is_count_tag,
+    is_rating_tag,
+)
 
 
 _CATEGORY_RE = re.compile(r"^\s*\[([^\]]+)\]")
@@ -283,7 +288,10 @@ def correct_caption(
         *buckets["quality"],
         *buckets["meta"],
         *buckets["year"],
-        *buckets["safety"],
+        # Rewrite legacy booru ratings to Anima's band (general→safe,
+        # questionable→nsfw); dict.fromkeys drops the duplicate a caption
+        # carrying both spellings would otherwise collapse into.
+        *dict.fromkeys(canonical_rating(t) or t for t in buckets["safety"]),
         *buckets["count"],
         *buckets["character"],
         *buckets["copyright"],
@@ -316,7 +324,7 @@ def _classify_tag(
     # Front region, in emit order: quality → meta → year → safety.
     if tag in _QUALITY_TAGS:
         return "quality"
-    if tag in CAPTION_RATINGS:
+    if is_rating_tag(tag):
         return "safety"
     if _is_year_tag(tag):
         return "year"

--- a/library/captioning/taxonomy.py
+++ b/library/captioning/taxonomy.py
@@ -48,5 +48,29 @@ def strip_artist_prefix(tag: str) -> str:
     return tag[1:] if tag.startswith("@") else tag
 
 
-# Raw-caption 4-class danbooru rating vocabulary (for stripping the leading rating band). Intentionally a superset of the tagger's 3-class MODEL-OUTPUT ratings (library.captioning.anima_tagger.RATINGS), which collapse questionable → sensitive.
-CAPTION_RATINGS = frozenset({"general", "sensitive", "questionable", "explicit"})
+# Anima's 4-class rating vocabulary — the leading safety band of a caption
+# (``safe, 1girl, …``), and the same set the tagger's rating head predicts
+# (``library.captioning.anima_tagger.RATINGS``, which fixes the class order).
+CAPTION_RATINGS = frozenset({"safe", "sensitive", "nsfw", "explicit"})
+
+# Danbooru's own rating literals, mapped onto the Anima band. Anima renames two
+# of the four (``general``→``safe``, ``questionable``→``nsfw``) and keeps the
+# other two verbatim, so raw booru captions — and corpora/vocab.json built
+# before the rename — still read as ratings instead of falling through to the
+# ``general`` *category*.
+LEGACY_RATING_ALIASES = {"general": "safe", "questionable": "nsfw"}
+
+# Every literal that reads as a rating: canonical band + accepted legacy spellings.
+RATING_LITERALS = CAPTION_RATINGS | frozenset(LEGACY_RATING_ALIASES)
+
+
+def is_rating_tag(tag: str) -> bool:
+    """True for any accepted rating literal (canonical Anima or legacy booru)."""
+    return tag in RATING_LITERALS
+
+
+def canonical_rating(tag: str) -> str | None:
+    """The canonical Anima rating for ``tag``, or None when it isn't a rating."""
+    if tag in CAPTION_RATINGS:
+        return tag
+    return LEGACY_RATING_ALIASES.get(tag)

--- a/scripts/anima_tagger/vocab.py
+++ b/scripts/anima_tagger/vocab.py
@@ -36,7 +36,12 @@ from library.captioning.anima_tagger import (
     TAG_TYPE_NAMES,
 )
 
-from library.captioning.taxonomy import is_artist_tag, strip_artist_prefix
+from library.captioning.taxonomy import (
+    canonical_rating,
+    is_artist_tag,
+    is_rating_tag,
+    strip_artist_prefix,
+)
 
 from .constants import (
     classify_people,
@@ -161,8 +166,9 @@ def categorize(
 
     Resolution order:
 
-    1. Rating literals (``general``/``sensitive``/``explicit``) → ``rating``.
-       Note ``general`` is *both* a rating value and a category name, so
+    1. Rating literals (``safe``/``sensitive``/``nsfw``/``explicit``, plus the
+       legacy booru spellings ``general``/``questionable``) → ``rating``.
+       Note ``general`` is *both* a legacy rating value and a category name, so
        rating-tag membership is checked before any category lookup.
     2. ``@<non-space>...`` tags → ``artist``. Anima's caption format
        prefixes artists with ``@`` directly followed by the name (e.g.
@@ -180,7 +186,7 @@ def categorize(
     """
     # Rating literals collide with the "general" category name — slot them
     # separately regardless of cache typing (the cache carries no rating values).
-    if tag in RATINGS:
+    if is_rating_tag(tag):
         return "rating"
     if is_artist_tag(tag):
         return "artist"
@@ -232,11 +238,14 @@ def build_vocab(
 
     for stem, (_, _, tags) in caption_index.items():
         # Pull rating off the front (Anima puts it first; scan the first few
-        # defensively); everything else feeds the multi-label vocab.
+        # defensively); everything else feeds the multi-label vocab. Legacy
+        # booru spellings are folded onto the canonical band so a mixed corpus
+        # reports one distribution rather than two.
         rating_seen: Optional[str] = None
         for t in tags[:2]:
-            if t in RATINGS:
-                rating_seen = t
+            canon = canonical_rating(t)
+            if canon is not None:
+                rating_seen = canon
                 break
         if rating_seen is not None:
             rating_freq[rating_seen] += 1
@@ -247,7 +256,7 @@ def build_vocab(
         people_freq[PEOPLE_COUNT_LABELS[classify_people(tags)]] += 1
 
         for i, tag in enumerate(tags):
-            if tag in RATINGS:
+            if is_rating_tag(tag):
                 continue
             freq[tag] += 1
             sum_pos[tag] += i
@@ -351,14 +360,21 @@ def build_manifest(
             continue
         rating_idx: Optional[int] = None
         for t in tags[:2]:
-            if t in rating_to_idx:
-                rating_idx = rating_to_idx[t]
+            # Raw literal first so a vocab.json built before the safe/nsfw
+            # rename still indexes its own spellings; canonical form second so
+            # a legacy caption lands in the renamed band.
+            hit = rating_to_idx.get(t)
+            if hit is None:
+                canon = canonical_rating(t)
+                hit = rating_to_idx.get(canon) if canon is not None else None
+            if hit is not None:
+                rating_idx = hit
                 break
         if rating_idx is None:
             n_no_rating += 1
             continue
         idxs = sorted(
-            tag_to_idx[t] for t in tags if t in tag_to_idx and t not in rating_to_idx
+            tag_to_idx[t] for t in tags if t in tag_to_idx and not is_rating_tag(t)
         )
         if not idxs:
             n_no_tags += 1
@@ -418,7 +434,7 @@ def scan_cache_coverage(
     missing: Counter = Counter()
     for _, (_, _, tags) in caption_index.items():
         for tag in tags:
-            if tag in RATINGS:
+            if is_rating_tag(tag):
                 continue
             if ignore_subs and any(sub in tag for sub in ignore_subs):
                 continue

--- a/scripts/preprocess/build_caption_index.py
+++ b/scripts/preprocess/build_caption_index.py
@@ -43,7 +43,7 @@ from pathlib import Path
 
 # Shared torch-free tag-shape primitives, kept in sync with the Anima Tagger
 # vocab build (scripts/anima_tagger/vocab.py).
-from library.captioning.taxonomy import CAPTION_RATINGS, is_artist_tag, is_count_tag
+from library.captioning.taxonomy import is_artist_tag, is_count_tag, is_rating_tag
 from library.datasets.image_utils import IMAGE_EXTENSIONS
 from library.datasets.subsets import filter_paths_by_glob
 from library.io.cache import caption_key
@@ -224,7 +224,7 @@ def _classify(
                     or tag in seen["count"]
                 ):
                     continue
-                if tag in CAPTION_RATINGS or is_count_tag(tag) or _PAREN_RE.match(tag):
+                if is_rating_tag(tag) or is_count_tag(tag) or _PAREN_RE.match(tag):
                     continue
                 if _norm_words(tag) & copy_words:
                     continue  # franchise sub-title of a known copyright

--- a/tests/test_tag_taxonomy.py
+++ b/tests/test_tag_taxonomy.py
@@ -65,14 +65,29 @@ def test_is_count_tag():
         assert not tx.is_count_tag(t), t
 
 
-def test_caption_ratings_superset_of_model_ratings():
-    # CAPTION_RATINGS (raw, 4-class) is a superset of the tagger's model-output
-    # RATINGS (3-class, after questionable→sensitive collapse).
+def test_caption_ratings_are_the_anima_band():
+    # The one rating vocabulary: Anima's 4-class band. The tagger's ordered
+    # RATINGS (class index for the rating head) must carry exactly the same
+    # members as the unordered CAPTION_RATINGS.
     from library.captioning.anima_tagger import RATINGS
 
-    assert set(RATINGS) <= tx.CAPTION_RATINGS
-    assert "questionable" in tx.CAPTION_RATINGS
-    assert "questionable" not in RATINGS
+    assert tx.CAPTION_RATINGS == {"safe", "sensitive", "nsfw", "explicit"}
+    assert set(RATINGS) == tx.CAPTION_RATINGS
+    assert len(RATINGS) == len(tx.CAPTION_RATINGS)  # no duplicate class index
+
+
+def test_legacy_booru_ratings_alias_onto_the_anima_band():
+    # Raw danbooru captions (and pre-rename vocab.json) still read as ratings.
+    assert tx.canonical_rating("general") == "safe"
+    assert tx.canonical_rating("questionable") == "nsfw"
+    for r in tx.CAPTION_RATINGS:
+        assert tx.canonical_rating(r) == r  # canonical spellings are fixpoints
+        assert tx.is_rating_tag(r)
+    for legacy in ("general", "questionable"):
+        assert tx.is_rating_tag(legacy)
+    for other in ("blue eyes", "1girl", "@sincos", "safety"):
+        assert not tx.is_rating_tag(other)
+        assert tx.canonical_rating(other) is None
 
 
 def test_index_and_tagger_agree_on_tag_shape():


### PR DESCRIPTION
The rating vocabulary was Danbooru's, not Anima's, and the two definitions
disagreed with each other and with the shipped prompts:

  taxonomy.CAPTION_RATINGS    {general, sensitive, questionable, explicit}
  anima_tagger.RATINGS        (general, sensitive, explicit)
  guidebook.md:209            absurdres, safe, 1girl, ...
  default sample prompt       ... score_7, safe. An anime girl ...

So `safe` — the literal the guidebook and every default sample prompt
actually use — was recognized nowhere, and `nsfw` appeared nowhere in the
repo at all. A caption starting with `safe` fell through categorize() to the
`general` *category*, landed in the multi-label tag vocab instead of the
rating band, and its stem was dropped from the tagger manifest as
dropped_no_rating.

Both constants now carry Anima's 4-class band. taxonomy gains
LEGACY_RATING_ALIASES (general→safe, questionable→nsfw) plus is_rating_tag()
/ canonical_rating(), so raw booru captions and pre-rename corpora still
classify as ratings; every membership test goes through those helpers rather
than comparing against one of the two sets. build_manifest resolves the raw
literal before the canonical one, keeping a pre-rename vocab.json indexing
its own spellings. correct_caption rewrites the safety slot to the canonical
band on emit.

Checkpoints are unaffected: AnimaTagger reads vocab["ratings"] from the
checkpoint and n_ratings flows from the manifest, so the shipped 3-class
checkpoint keeps loading and predicting its own labels. Rebuilding vocab
against the 4-class band widens the head — that is a retrain.

Tests: rating contract in test_tag_taxonomy.py rewritten (set equality with
CAPTION_RATINGS + no duplicate class index) and legacy-alias coverage added.
Vendor tree refreshed via `make vendor-sync`.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SFxtiEscHka1P9QUpBvscU