### PR TITLE
Add first-class Windows ROCm 7.14 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__/
+.pytest_cache/
 *.pyc
 *.pyo
 .venv
@@ -37,6 +38,7 @@ logs
 _logs/
 .claude
 .env
+.anima_backend
 .anima-update-backups
 node.zip
 _archive/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <img src="docs/gui.png" alt="Anima LoRA GUI — training-config editor with method/variant picker, inline method help, and live training monitor" width="900">
 </p>
 
-One line — installs [uv](https://astral.sh/uv) and the **CUDA 13.2 toolkit** if missing, fetches the latest release, runs `uv sync` (Python 3.13 + torch), and on Windows opens the GUI (no git required). The installer is published as a signed-by-checksum release asset:
+One line — installs [uv](https://astral.sh/uv), selects NVIDIA CUDA or AMD ROCm on Windows, fetches the latest release, runs `uv sync` (Python 3.13 + torch), and opens the GUI (no git required). The installer is published as a signed-by-checksum release asset:
 
 ```bash
 # Linux / macOS
@@ -17,9 +17,11 @@ curl -LsSf https://github.com/sorryhyun/anima_lora/releases/latest/download/inst
 irm https://github.com/sorryhyun/anima_lora/releases/latest/download/install.ps1 | iex
 ```
 
-> **Requirements:** at least an Ampere GPU (RTX 3000-series / A100 or newer) + NVIDIA driver **≥595**. The installer sets up the **CUDA 13.2 toolkit, Python 3.13, and PyTorch 2.12** for you.
+> **Requirements:** NVIDIA needs at least an Ampere GPU (RTX 3000-series / A100 or newer) and driver **≥595**. The initial Windows ROCm path targets RDNA 4 (`gfx1200` / `gfx1201`) and is certified for Radeon RX 9070 XT. The installer sets up **Python 3.13 + PyTorch 2.12** and either CUDA 13.2 or ROCm 7.14.
 
 Installs into `./anima_lora/` (override with `ANIMA_DIR`). On Windows it also drops an **"Anima LoRA GUI"** shortcut on your desktop.
+
+Windows selects the GPU vendor automatically. Override detection before running the installer with `$env:ANIMA_BACKEND='cuda'` or `$env:ANIMA_BACKEND='rocm'`. ROCm uses PyTorch SDPA for attention and keeps `torch_compile = true`; CUDA keeps the existing Flash Attention path.
 
 <details>
 <summary><b>Safer install</b> — inspect &amp; verify the script before running</summary>
@@ -185,14 +187,20 @@ Adapter families that train something — a LoRA-style delta, a routing head, or
 ### Manual (from a clone)
 
 ```bash
-uv sync                   # Python 3.13 with pre-built flash attention 2
+# Linux / macOS
+uv sync
+
+# Windows: select exactly one backend
+uv sync --extra cuda-windows
+uv sync --extra rocm-windows
+
 hf auth login             # or just sign in from the GUI — auth is built in now
 make download-models      # DiT + Qwen3 TE + QwenImage VAE (+ SAM3 / MIT / PE for masking & image conditioning) into models/
 # place training images in image_dataset/ with .txt caption sidecars
 make gui                  # recommended — config editor + dataset browser + training monitor
 ```
 
-`uv sync` resolves to **torch 2.12 + CUDA 13.2** runtime. The manual clone path does **not** auto-install the CUDA 13.2 **toolkit** (needed for `torch.compile`/Triton) — install it per [guidebook §2](docs/guidelines/guidebook.md#2-cuda-132-handled-by-the-installer), or just run the one-line installer above, which does it for you.
+On Windows, the extras are mutually exclusive so `uv` cannot mix CUDA and ROCm wheels. Reuse the same extra for later manual `uv sync` commands. `make update` remembers the backend selected by the installer. The CUDA manual-clone path does **not** auto-install the CUDA 13.2 **toolkit** (needed for `torch.compile`/Triton) — install it per [guidebook §2](docs/guidelines/guidebook.md#2-cuda-132-handled-by-the-installer), or use the one-line installer above. The ROCm extra uses AMD's official ROCm 7.14 package index and does not install Flash Attention; `triton-windows` remains present because it supplies the Windows runtime used by `torch.compile` on both backends.
 
 > **Anima ships as a uv-locked application environment, not a generic pip package.** `pyproject.toml` pins `python ==3.13.*`, specific torch / flash-attn wheel URLs, and `index-strategy = "unsafe-best-match"` — these are maintainer-chosen, known-good builds. Install with `uv sync` against the committed `uv.lock`; don't `pip install` from `pyproject.toml` (pip won't honor uv's index strategy or the prebuilt flash-attn wheels).
 

--- a/docs/guidelines/guidebook.md
+++ b/docs/guidelines/guidebook.md
@@ -23,6 +23,14 @@ This document is a comprehensive English guide for using the **Anima LoRA** trai
 
 ## 1. System Requirements
 
+> **Windows AMD / ROCm:** Windows Radeon support is available through the same
+> one-line installer used for NVIDIA. The installer auto-detects the GPU vendor,
+> selects the ROCm dependency set for AMD, and keeps `torch.compile` enabled
+> while using PyTorch SDPA instead of CUDA Flash Attention. The currently
+> verified ROCm targets are RDNA 4 `gfx1200` / `gfx1201`. See
+> [Windows ROCm Guide](rocm.md) for supported hardware, version pinning, manual
+> setup, and troubleshooting.
+
 | Item | Minimum | Recommended |
 |---|---|---|
 | GPU | At least **RTX 3060 or higher — 2xxx series and below are not supported** | VRAM 16 GB or more |
@@ -65,10 +73,10 @@ This project uses [`uv`](https://github.com/astral-sh/uv) for dependency managem
 
 ### 3.0 One-line install (easiest, no git required) ✅
 
-Recommended for beginners. Paste this single line into PowerShell — it installs `uv` if missing, **installs the CUDA 13.2 toolkit if missing** (see **§2**), downloads the latest release, runs `uv sync` (Python 3.13 + torch are resolved automatically), creates an **"Anima LoRA GUI" desktop shortcut**, and **opens the GUI for you**:
+Recommended for beginners. Paste this single line into PowerShell — the installer auto-detects NVIDIA vs AMD, installs `uv` if missing, installs the **CUDA 13.2 toolkit only for NVIDIA** (see **§2**), selects ROCm automatically for AMD, downloads the latest release, creates an **"Anima LoRA GUI" desktop shortcut**, and **opens the GUI for you**:
 
 ```powershell
-irm https://raw.githubusercontent.com/sorryhyun/anima_lora/main/install.ps1 | iex
+irm https://github.com/sorryhyun/anima_lora/releases/latest/download/install.ps1 | iex
 ```
 
 Installs into `.\anima_lora\` (override with `$env:ANIMA_DIR`; pin a version with `$env:ANIMA_VERSION='v1.4.0'`). **When it finishes, the GUI opens by itself** — from there:

--- a/docs/guidelines/rocm.md
+++ b/docs/guidelines/rocm.md
@@ -1,0 +1,171 @@
+# Windows ROCm Guide
+
+This document covers the AMD Radeon / ROCm path for Anima LoRA on Windows.
+The normal beginner workflow is intentionally the same as the CUDA workflow:
+use the one-line installer, then use the GUI. You do not need to choose PyTorch
+indexes or `uv` extras manually.
+
+## Beginner install
+
+Open PowerShell in the folder where you want Anima LoRA to be installed and run:
+
+```powershell
+irm https://github.com/sorryhyun/anima_lora/releases/latest/download/install.ps1 | iex
+```
+
+The installer will:
+
+1. detect the Windows GPU vendor;
+2. select the CUDA or ROCm dependency set automatically;
+3. install the locked Python / PyTorch environment;
+4. save the selected backend for later updates;
+5. verify the ROCm runtime when AMD is selected;
+6. create the **Anima LoRA GUI** desktop shortcut; and
+7. launch the GUI.
+
+For normal use, there is no separate AMD installation procedure after this.
+Use the GUI for model download, preprocessing, training, and updates.
+
+### Updating
+
+Use the **Update** button in the GUI.
+
+The installer stores the selected Windows backend in `.anima_backend`, and the
+updater reuses it. An existing ROCm installation therefore stays on the ROCm
+dependency path instead of being silently replaced by CUDA packages.
+
+## Current verified hardware scope
+
+The locked ROCm environment in this project currently packages and verifies
+RDNA 4 only:
+
+| Architecture | Tested hardware | Status |
+|---|---|---|
+| `gfx1200` | Radeon RX 9060 XT | Verified |
+| `gfx1201` | Radeon RX 9070 XT | Verified |
+
+Both devices were tested with the exact ROCm 7.14 Windows environment using
+tensor allocation, `torch.compile`, bf16 PyTorch SDPA, backward, finite-value
+checks, and device synchronization.
+
+AMD's ROCm 7.14 PyTorch package repository also publishes device packages for
+RDNA 3 (`gfx1100`, `gfx1101`, `gfx1102`, and `gfx1103`). The same packaging
+approach is expected to extend to those architectures, but they are not part of
+the declared support set here until they receive the same hardware smoke test.
+
+> The installer currently detects the GPU vendor, not the exact AMD GPU
+> architecture. The committed ROCm dependency set contains only `gfx1200` and
+> `gfx1201`, so other AMD GPUs should be treated as unverified even if the
+> installer selects ROCm.
+
+## Locked software stack
+
+The supported Windows ROCm environment for this integration is pinned to:
+
+- Python 3.13
+- PyTorch `2.12.0+rocm7.14.0`
+- torchvision `0.27.0+rocm7.14.0`
+- ROCm / HIP 7.14 device packages for `gfx1200` and `gfx1201`
+- `triton-windows` for the Windows `torch.compile` runtime
+
+The runtime/backend code is not fundamentally tied to PyTorch 2.12. The exact
+2.12 pin exists because it is the ROCm 7.14 Windows package combination used by
+this release and matches Anima LoRA's current CUDA PyTorch baseline.
+
+For development-only compatibility checking, the same core Anima / ROCm path
+has also been exercised locally with:
+
+- PyTorch 2.14 alpha + ROCm 7.15 alpha
+- PyTorch 2.15 alpha + ROCm 10.1 alpha
+
+Those development stacks are **not** the locked or advertised supported
+configuration. They only indicate that the backend integration itself is not
+intrinsically coupled to PyTorch 2.12.
+
+## Attention behavior on ROCm
+
+The CUDA build keeps the existing Flash Attention path.
+
+On ROCm, an explicit `attn_mode = "flash"` request is normalized to PyTorch
+SDPA instead. The ROCm environment therefore does not install an AMD Flash
+Attention dependency, while `torch_compile = true` remains enabled.
+
+This separation is intentional: ROCm-specific dependency and attention choices
+stay behind the backend selection so CUDA users keep the existing CUDA toolkit,
+Flash Attention, and dependency workflow.
+
+## Manual clone / advanced setup
+
+The one-line installer above is recommended. If you intentionally install from
+a git clone on Windows, select exactly one backend extra.
+
+ROCm:
+
+```powershell
+uv sync --extra rocm-windows
+```
+
+CUDA:
+
+```powershell
+uv sync --extra cuda-windows
+```
+
+The two Windows extras are declared mutually exclusive so `uv` cannot resolve a
+mixed CUDA/ROCm Torch environment.
+
+To force ROCm when using the one-line installer:
+
+```powershell
+$env:ANIMA_BACKEND = 'rocm'
+irm https://github.com/sorryhyun/anima_lora/releases/latest/download/install.ps1 | iex
+```
+
+`ANIMA_BACKEND` accepts `auto`, `cuda`, or `rocm`. Automatic detection prefers
+CUDA on a mixed NVIDIA + AMD system in order to preserve the historical CUDA
+default; use the override above if ROCm is intentional.
+
+## Runtime smoke test
+
+A manual ROCm installation can run the same post-install check used by the
+installer:
+
+```powershell
+uv run --extra rocm-windows python scripts/rocm_smoke_test.py
+```
+
+A successful run verifies the key training path rather than only checking that
+`import torch` works.
+
+## Troubleshooting
+
+### The installer selected ROCm for an older or unverified AMD GPU
+
+The current locked device set is `gfx1200` / `gfx1201`. Other Radeon
+architectures are not yet declared verified by this project. If you want to add
+an RDNA 3 target, use the appropriate ROCm device package and run
+`scripts/rocm_smoke_test.py` on real hardware before treating it as supported.
+
+### `ROCm detected: using PyTorch SDPA instead of CUDA Flash Attention`
+
+This message is expected when the configuration explicitly requests `flash` on
+a HIP build. The runtime switches that request to PyTorch SDPA. `attn_mode=None`
+or an explicit `torch` request does not count as a ROCm fallback.
+
+### The ROCm smoke test fails
+
+Do not continue with training until the smoke test passes. Confirm that the
+installed environment is the `rocm-windows` extra and that the GPU is within the
+currently packaged architecture set. Re-running the one-line installer in a new
+empty target directory is the simplest clean-install check.
+
+## Maintenance summary
+
+For the normal Windows workflow, backend selection remains centralized in the
+installer and updater:
+
+- NVIDIA users keep CUDA 13.2 + CUDA PyTorch + Flash Attention.
+- AMD users receive the ROCm PyTorch package set + PyTorch SDPA.
+- `.anima_backend` preserves the selected path across updates.
+- Beginner documentation can continue to point to the same one-line installer
+  and GUI Update button for both vendors.

--- a/install.ps1
+++ b/install.ps1
@@ -2,7 +2,8 @@
 #
 #   irm https://raw.githubusercontent.com/sorryhyun/anima_lora/main/install.ps1 | iex
 #
-# Installs uv if missing, guides the CUDA 13.2 toolkit install if missing,
+# Installs uv if missing, selects CUDA or ROCm, guides the CUDA 13.2 toolkit
+# install if needed,
 # downloads the latest release tarball (no git required), seeds the update
 # baseline so the first `make update` is clean, and runs `uv sync`. Mirrors
 # scripts/update.py — keep the two in sync.
@@ -10,16 +11,42 @@
 # Options (env vars, since args don't pass through `irm | iex`):
 #   $env:ANIMA_VERSION    = 'v1.4.0'   install a specific tag   (default: latest)
 #   $env:ANIMA_DIR        = 'C:\path'  target directory         (default: .\anima_lora)
+#   $env:ANIMA_BACKEND    = 'auto'     auto | cuda | rocm        (default: auto)
 #   $env:ANIMA_SKIP_CUDA  = '1'        skip the CUDA 13.2 toolkit install/check
 
 $ErrorActionPreference = 'Stop'
 $Repo    = 'sorryhyun/anima_lora'
 $Version = $env:ANIMA_VERSION
 $Dir     = if ($env:ANIMA_DIR) { $env:ANIMA_DIR } else { 'anima_lora' }
+$Backend = if ($env:ANIMA_BACKEND) { $env:ANIMA_BACKEND.ToLowerInvariant() } else { 'auto' }
 
 function Say($m)  { Write-Host "==> $m" -ForegroundColor Cyan }
 function Die($m)  { Write-Host "error: $m" -ForegroundColor Red; exit 1 }
 function Warn($m) { Write-Host "warning: $m" -ForegroundColor Yellow }
+
+if ($Backend -notin @('auto', 'cuda', 'rocm')) {
+  Die "ANIMA_BACKEND must be auto, cuda, or rocm (got '$Backend')"
+}
+
+if ($Backend -eq 'auto') {
+  try {
+    $gpuNames = @(Get-CimInstance Win32_VideoController -ErrorAction Stop |
+      ForEach-Object { "$($_.Name) $($_.AdapterCompatibility)" })
+  } catch {
+    $gpuNames = @()
+    Warn 'GPU vendor detection failed; preserving the CUDA default'
+  }
+  $hasNvidia = [bool]($gpuNames -match '(?i)NVIDIA')
+  $hasAmd = [bool]($gpuNames -match '(?i)AMD|Advanced Micro Devices|Radeon')
+  if ($hasNvidia) {
+    $Backend = 'cuda' # Preserve the existing default on mixed-vendor systems.
+  } elseif ($hasAmd) {
+    $Backend = 'rocm'
+  } else {
+    $Backend = 'cuda'
+  }
+}
+Say "selected $Backend backend (override with ANIMA_BACKEND=auto|cuda|rocm)"
 
 # 0. neutralize an active Conda env (GH #21) ---------------------------------
 # With `conda activate base` live, conda's Library\bin sits on PATH. uv builds
@@ -69,7 +96,9 @@ function Test-Cuda132 {
   }
   try { return [bool]((& $nvcc --version 2>$null) -match 'release 13\.2([^0-9]|$)') } catch { return $false }
 }
-if ($env:ANIMA_SKIP_CUDA) {
+if ($Backend -eq 'rocm') {
+  Say 'ROCm selected - skipping the NVIDIA CUDA toolkit check'
+} elseif ($env:ANIMA_SKIP_CUDA) {
   Say 'ANIMA_SKIP_CUDA set — skipping the CUDA 13.2 toolkit check'
 } elseif (Test-Cuda132) {
   Say 'CUDA 13.2 toolkit detected'
@@ -148,6 +177,10 @@ try {
 
 Set-Location $Dir
 
+# Persist the install choice for scripts/update.py. This local file is ignored
+# by git and survives release updates.
+Set-Content -LiteralPath '.anima_backend' -Value $Backend -Encoding ascii
+
 # 4. seed the update baseline (before uv sync, so .venv isn't hashed) --------
 Say 'seeding update baseline (.anima_release.json)'
 try {
@@ -171,10 +204,11 @@ try {
   # not elevated, third-party AV, or Defender disabled -- retry loop handles it
 }
 
-Say 'running uv sync (this resolves torch + flash-attn; may take a while)'
+$BackendExtra = if ($Backend -eq 'rocm') { 'rocm-windows' } else { 'cuda-windows' }
+Say "running uv sync --extra $BackendExtra (may take a while)"
 $syncOk = $false
 for ($attempt = 1; $attempt -le 3; $attempt++) {
-  uv sync
+  uv sync --extra $BackendExtra
   if ($LASTEXITCODE -eq 0) { $syncOk = $true; break }
   if ($attempt -lt 3) {
     Say "uv sync failed (exit $LASTEXITCODE); retrying ($attempt/2) in 3s -- often a transient antivirus lock on a trampoline .exe"
@@ -199,6 +233,12 @@ trampoline .exe files. To fix:
      'uv sync', then turn it back on.
 "@ -ForegroundColor Yellow
   Die 'dependency install incomplete'
+}
+
+if ($Backend -eq 'rocm') {
+  Say 'verifying the ROCm PyTorch runtime'
+  uv run --extra rocm-windows python scripts/rocm_smoke_test.py
+  if ($LASTEXITCODE -ne 0) { Die 'ROCm PyTorch smoke test failed' }
 }
 
 # 6. shortcuts (best-effort — never abort the install over this) -------------

--- a/library/inference/models.py
+++ b/library/inference/models.py
@@ -393,10 +393,18 @@ def load_dit_model(
     else:
         lora_weights_list = None
 
+    from library.runtime.backend import resolve_attention_mode
+
+    attn_mode = resolve_attention_mode(args.attn_mode, torch)
+    if attn_mode != args.attn_mode:
+        logger.warning(
+            "ROCm detected: using PyTorch SDPA instead of CUDA Flash Attention"
+        )
+
     model = anima_utils.load_anima_model(
         device,
         args.dit,
-        args.attn_mode,
+        attn_mode,
         loading_device,
         dit_weight_dtype,
         lora_weights_list=lora_weights_list,

--- a/library/inference/models.py
+++ b/library/inference/models.py
@@ -393,10 +393,13 @@ def load_dit_model(
     else:
         lora_weights_list = None
 
-    from library.runtime.backend import resolve_attention_mode
+    from library.runtime.backend import (
+        needs_rocm_attention_fallback,
+        resolve_attention_mode,
+    )
 
     attn_mode = resolve_attention_mode(args.attn_mode, torch)
-    if attn_mode != args.attn_mode:
+    if needs_rocm_attention_fallback(args.attn_mode, torch):
         logger.warning(
             "ROCm detected: using PyTorch SDPA instead of CUDA Flash Attention"
         )

--- a/library/runtime/backend.py
+++ b/library/runtime/backend.py
@@ -1,0 +1,18 @@
+"""Runtime accelerator compatibility helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def is_rocm(torch_module: Any) -> bool:
+    """Return whether *torch_module* is a ROCm/HIP PyTorch build."""
+    return getattr(getattr(torch_module, "version", None), "hip", None) is not None
+
+
+def resolve_attention_mode(requested: str | None, torch_module: Any) -> str:
+    """Use PyTorch SDPA when the CUDA-only Flash backend is selected on ROCm."""
+    mode = requested or "torch"
+    if mode == "flash" and is_rocm(torch_module):
+        return "torch"
+    return mode

--- a/library/runtime/backend.py
+++ b/library/runtime/backend.py
@@ -10,9 +10,16 @@ def is_rocm(torch_module: Any) -> bool:
     return getattr(getattr(torch_module, "version", None), "hip", None) is not None
 
 
+def needs_rocm_attention_fallback(
+    requested: str | None, torch_module: Any
+) -> bool:
+    """Return whether an explicit Flash request must fall back on ROCm."""
+    return requested == "flash" and is_rocm(torch_module)
+
+
 def resolve_attention_mode(requested: str | None, torch_module: Any) -> str:
     """Use PyTorch SDPA when the CUDA-only Flash backend is selected on ROCm."""
     mode = requested or "torch"
-    if mode == "flash" and is_rocm(torch_module):
+    if needs_rocm_attention_fallback(requested, torch_module):
         return "torch"
     return mode

--- a/library/runtime/harness.py
+++ b/library/runtime/harness.py
@@ -109,7 +109,12 @@ def build_anima(
 
     device = torch.device(getattr(args, "device", "cuda"))
     dtype = str_to_dtype(getattr(args, "dtype", "bf16"))
-    attn_mode = getattr(args, "attn_mode", "flash")
+    from library.runtime.backend import resolve_attention_mode
+
+    requested_attn_mode = getattr(args, "attn_mode", "flash")
+    attn_mode = resolve_attention_mode(requested_attn_mode, torch)
+    if attn_mode != requested_attn_mode:
+        log.warning("ROCm detected: using PyTorch SDPA instead of CUDA Flash Attention")
 
     if dit_path is None:
         dit_path = getattr(args, "dit", None)

--- a/library/runtime/harness.py
+++ b/library/runtime/harness.py
@@ -109,11 +109,14 @@ def build_anima(
 
     device = torch.device(getattr(args, "device", "cuda"))
     dtype = str_to_dtype(getattr(args, "dtype", "bf16"))
-    from library.runtime.backend import resolve_attention_mode
+    from library.runtime.backend import (
+        needs_rocm_attention_fallback,
+        resolve_attention_mode,
+    )
 
     requested_attn_mode = getattr(args, "attn_mode", "flash")
     attn_mode = resolve_attention_mode(requested_attn_mode, torch)
-    if attn_mode != requested_attn_mode:
+    if needs_rocm_attention_fallback(requested_attn_mode, torch):
         log.warning("ROCm detected: using PyTorch SDPA instead of CUDA Flash Attention")
 
     if dit_path is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,11 @@ description = "Standalone Anima LoRA training pipeline"
 requires-python = "==3.13.*"
 dependencies = [
     # Core ML.
-    "torch>=2.12.0,<2.13",
-    "torchvision>=0.27.0,<0.28",
+    # Windows selects one accelerator extra in install.ps1. Keeping the two
+    # mutually exclusive prevents a later uv resolution from crossing CUDA
+    # and ROCm package indexes.
+    "torch>=2.12.0,<2.13 ; sys_platform != 'win32'",
+    "torchvision>=0.27.0,<0.28 ; sys_platform != 'win32'",
     "accelerate>=1.13.0",
     "transformers>=5.10.1",
     "diffusers>=0.39.0",
@@ -40,8 +43,6 @@ dependencies = [
     "pycocotools>=2.0.11",
     "flash-attn @ https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.9.17/flash_attn-2.8.3+cu132torch2.12-cp313-cp313-linux_x86_64.whl ; sys_platform == 'linux' and platform_machine == 'x86_64'",
     "flash-attn @ https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.9.22/flash_attn-2.8.3+cu132torch2.12-cp313-cp313-linux_aarch64.whl ; sys_platform == 'linux' and platform_machine == 'aarch64'",
-    "flash-attn @ https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.9.25/flash_attn-2.8.3+cu132torch2.12-cp313-cp313-win_amd64.whl ; sys_platform == 'win32'",
-    "triton-windows>=3.7.0,<3.8.0 ; sys_platform == 'win32'",
     "pyside6>=6.11.0",
     "ruff>=0.15.9",
     "matplotlib",
@@ -73,6 +74,22 @@ dependencies = [
 
 [project.optional-dependencies]
 gui = ["PySide6>=6.7"]
+cuda-windows = [
+    "torch==2.12.0+cu132 ; sys_platform == 'win32'",
+    "torchvision==0.27.0+cu132 ; sys_platform == 'win32'",
+    "flash-attn @ https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.9.25/flash_attn-2.8.3+cu132torch2.12-cp313-cp313-win_amd64.whl ; sys_platform == 'win32'",
+    "triton-windows>=3.7.0,<3.8.0 ; sys_platform == 'win32'",
+]
+rocm-windows = [
+    # Initial RDNA 4 path. AMD's device-all extra currently includes Linux-only
+    # Instinct packages and cannot resolve on Windows, so select gfx120X only.
+    "torch[device-gfx1200,device-gfx1201]==2.12.0+rocm7.14.0 ; sys_platform == 'win32'",
+    "torchvision[device-gfx1200,device-gfx1201]==0.27.0+rocm7.14.0 ; sys_platform == 'win32'",
+    # AMD's Windows wheel metadata currently points at a Linux-only `triton`
+    # distribution. The Windows package provides the same import/runtime used
+    # by torch.compile in the working ROCm environment.
+    "triton-windows>=3.7.0,<3.8.0 ; sys_platform == 'win32'",
+]
 dev = [
     "pytest>=8.0",
     "pytest-xdist>=3.6",
@@ -86,13 +103,42 @@ required-environments = [
     "sys_platform == 'win32'",
 ]
 index-strategy = "unsafe-best-match"
-# Both wheels are looked up from these indexes — the version pin in
-# `dependencies` (active vs. commented) decides which one resolves.
-extra-index-url = [
-    "https://download.pytorch.org/whl/cu132"
+conflicts = [
+    [
+        { extra = "cuda-windows" },
+        { extra = "rocm-windows" },
+    ],
 ]
 prerelease = "allow"
-override-dependencies = ["numpy>=2.0.0"]
+override-dependencies = [
+    "numpy>=2.0.0",
+    # AMD's torch metadata requests a Linux-only triton distribution even on
+    # Windows. triton-windows is declared in both Windows backend extras.
+    "triton ; sys_platform != 'win32'",
+]
+
+[tool.uv.sources]
+torch = [
+    { index = "pytorch-cu132", marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
+    { index = "pytorch-cu132", extra = "cuda-windows" },
+    { index = "amd-rocm-714", extra = "rocm-windows" },
+]
+torchvision = [
+    { index = "pytorch-cu132", marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
+    { index = "pytorch-cu132", extra = "cuda-windows" },
+    { index = "amd-rocm-714", extra = "rocm-windows" },
+]
+
+[[tool.uv.index]]
+name = "pytorch-cu132"
+url = "https://download.pytorch.org/whl/cu132"
+explicit = true
+
+# This index also hosts the ROCm runtime/device packages pulled by the device
+# extras, so it cannot be explicit-only.
+[[tool.uv.index]]
+name = "amd-rocm-714"
+url = "https://repo.amd.com/rocm/whl-multi-arch/"
 
 [tool.ruff.lint.per-file-ignores]
 # `train.py` / `inference.py` call `install_no_window_default()` at module scope

--- a/scripts/rocm_smoke_test.py
+++ b/scripts/rocm_smoke_test.py
@@ -18,16 +18,26 @@ def main() -> int:
     if torch.version.hip is None:
         raise RuntimeError("installed PyTorch is not a ROCm build")
 
-    # Exercise device allocation, compile, and backward rather than accepting
-    # an import-only success, which misses runtime/device/Triton failures.
+    # Exercise device allocation, compile, SDPA, and backward rather than
+    # accepting an import-only success, which misses runtime/device/Triton
+    # failures and the attention path used by Anima on ROCm.
     @torch.compile
     def compiled_loss(value: torch.Tensor) -> torch.Tensor:
         return value.square().mean()
 
     x = torch.randn(64, 64, device="cuda", requires_grad=True)
     compiled_loss(x).backward()
+
+    q = torch.randn(
+        2, 4, 64, 64, device="cuda", dtype=torch.bfloat16, requires_grad=True
+    )
+    attention = torch.nn.functional.scaled_dot_product_attention(q, q, q)
+    attention.float().square().mean().backward()
     torch.cuda.synchronize()
-    print("ROCm tensor/compile/backward smoke test: OK")
+    if not torch.isfinite(attention).all() or not torch.isfinite(q.grad).all():
+        raise RuntimeError("ROCm PyTorch SDPA produced non-finite values")
+
+    print("ROCm tensor/compile/SDPA/backward smoke test: OK")
     return 0
 
 

--- a/scripts/rocm_smoke_test.py
+++ b/scripts/rocm_smoke_test.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Small post-install check for the supported Windows ROCm path."""
+
+from __future__ import annotations
+
+import torch
+
+
+def main() -> int:
+    print(f"torch: {torch.__version__}")
+    print(f"HIP: {torch.version.hip}")
+    print(
+        f"GPU: {torch.cuda.get_device_name(0) if torch.cuda.is_available() else 'unavailable'}"
+    )
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("ROCm PyTorch cannot access an AMD GPU")
+    if torch.version.hip is None:
+        raise RuntimeError("installed PyTorch is not a ROCm build")
+
+    # Exercise device allocation, compile, and backward rather than accepting
+    # an import-only success, which misses runtime/device/Triton failures.
+    @torch.compile
+    def compiled_loss(value: torch.Tensor) -> torch.Tensor:
+        return value.square().mean()
+
+    x = torch.randn(64, 64, device="cuda", requires_grad=True)
+    compiled_loss(x).backward()
+    torch.cuda.synchronize()
+    print("ROCm tensor/compile/backward smoke test: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/update.py
+++ b/scripts/update.py
@@ -32,6 +32,7 @@ import difflib
 import fnmatch
 import hashlib
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -53,6 +54,46 @@ for _stream in (sys.stdout, sys.stderr):
             pass
 
 ROOT = Path(__file__).resolve().parent.parent
+
+
+def _selected_windows_backend() -> str:
+    """Keep the accelerator chosen at install time across release updates."""
+    override = os.environ.get("ANIMA_BACKEND", "").strip().lower()
+    if override in {"cuda", "rocm"}:
+        return override
+
+    marker = ROOT / ".anima_backend"
+    if marker.is_file():
+        saved = marker.read_text(encoding="ascii").strip().lower()
+        if saved in {"cuda", "rocm"}:
+            return saved
+
+    # Existing installs predate the marker. Preserve a working ROCm venv when
+    # possible; otherwise retain the historical CUDA default.
+    python = ROOT / ".venv" / "Scripts" / "python.exe"
+    if python.is_file():
+        try:
+            result = subprocess.run(
+                [str(python), "-c", "import torch; print(bool(torch.version.hip))"],
+                cwd=ROOT,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            if result.stdout.strip() == "True":
+                return "rocm"
+        except (OSError, subprocess.CalledProcessError):
+            pass
+    return "cuda"
+
+
+def _uv_sync_command() -> list[str]:
+    command = ["uv", "sync"]
+    if sys.platform == "win32":
+        command.extend(["--extra", f"{_selected_windows_backend()}-windows"])
+    return command
+
+
 REPO = "sorryhyun/anima_lora"
 MANIFEST_FILE = ROOT / ".anima_release.json"
 BACKUP_ROOT = ROOT / ".anima-update-backups"
@@ -527,9 +568,10 @@ def _apply(
     print(f"\nmanifest updated: {MANIFEST_FILE.name} → {new_tag}")
 
     if not no_sync:
-        print("\nrunning uv sync …")
+        sync_command = _uv_sync_command()
+        print(f"\nrunning {' '.join(sync_command)} …")
         try:
-            subprocess.run(["uv", "sync"], cwd=ROOT, check=True)
+            subprocess.run(sync_command, cwd=ROOT, check=True)
         except FileNotFoundError:
             print("  uv not found on PATH; skip or run `uv sync` manually")
         except subprocess.CalledProcessError as e:

--- a/tests/test_rocm_backend.py
+++ b/tests/test_rocm_backend.py
@@ -2,7 +2,11 @@ import tomllib
 from pathlib import Path
 from types import SimpleNamespace
 
-from library.runtime.backend import is_rocm, resolve_attention_mode
+from library.runtime.backend import (
+    is_rocm,
+    needs_rocm_attention_fallback,
+    resolve_attention_mode,
+)
 from scripts import update
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -28,6 +32,18 @@ def test_rocm_keeps_explicit_non_flash_modes():
 
 def test_cuda_keeps_flash():
     assert resolve_attention_mode("flash", _torch(None)) == "flash"
+
+
+def test_none_request_does_not_report_rocm_fallback():
+    assert resolve_attention_mode(None, _torch(None)) == "torch"
+    assert not needs_rocm_attention_fallback(None, _torch(None))
+    assert not needs_rocm_attention_fallback(None, _torch("7.14.0"))
+
+
+def test_only_explicit_rocm_flash_request_reports_fallback():
+    assert needs_rocm_attention_fallback("flash", _torch("7.14.0"))
+    assert not needs_rocm_attention_fallback("torch", _torch("7.14.0"))
+    assert not needs_rocm_attention_fallback("flash", _torch(None))
 
 
 def test_update_reuses_saved_rocm_backend(monkeypatch, tmp_path):

--- a/tests/test_rocm_backend.py
+++ b/tests/test_rocm_backend.py
@@ -1,0 +1,68 @@
+import tomllib
+from pathlib import Path
+from types import SimpleNamespace
+
+from library.runtime.backend import is_rocm, resolve_attention_mode
+from scripts import update
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _torch(hip):
+    return SimpleNamespace(version=SimpleNamespace(hip=hip))
+
+
+def test_rocm_detection_uses_hip_version():
+    assert is_rocm(_torch("7.14.0"))
+    assert not is_rocm(_torch(None))
+
+
+def test_rocm_flash_falls_back_to_torch_sdpa():
+    assert resolve_attention_mode("flash", _torch("7.14.0")) == "torch"
+
+
+def test_rocm_keeps_explicit_non_flash_modes():
+    assert resolve_attention_mode("flex", _torch("7.14.0")) == "flex"
+    assert resolve_attention_mode("torch", _torch("7.14.0")) == "torch"
+
+
+def test_cuda_keeps_flash():
+    assert resolve_attention_mode("flash", _torch(None)) == "flash"
+
+
+def test_update_reuses_saved_rocm_backend(monkeypatch, tmp_path):
+    (tmp_path / ".anima_backend").write_text("rocm\n", encoding="ascii")
+    monkeypatch.setattr(update, "ROOT", tmp_path)
+    monkeypatch.setattr(update.sys, "platform", "win32")
+    monkeypatch.delenv("ANIMA_BACKEND", raising=False)
+
+    assert update._uv_sync_command() == [
+        "uv",
+        "sync",
+        "--extra",
+        "rocm-windows",
+    ]
+
+
+def test_update_environment_override_wins(monkeypatch, tmp_path):
+    (tmp_path / ".anima_backend").write_text("rocm\n", encoding="ascii")
+    monkeypatch.setattr(update, "ROOT", tmp_path)
+    monkeypatch.setattr(update.sys, "platform", "win32")
+    monkeypatch.setenv("ANIMA_BACKEND", "cuda")
+
+    assert update._selected_windows_backend() == "cuda"
+
+
+def test_windows_backend_dependencies_are_isolated():
+    with (ROOT / "pyproject.toml").open("rb") as file:
+        project = tomllib.load(file)
+
+    extras = project["project"]["optional-dependencies"]
+    cuda = "\n".join(extras["cuda-windows"])
+    rocm = "\n".join(extras["rocm-windows"])
+
+    assert "+cu132" in cuda
+    assert "flash_attn" in cuda
+    assert "+rocm7.14.0" in rocm
+    assert "device-gfx1200" in rocm and "device-gfx1201" in rocm
+    assert "flash" not in rocm

--- a/train.py
+++ b/train.py
@@ -452,11 +452,14 @@ class AnimaTrainer:
         loading_dtype = weight_dtype
         loading_device = "cpu" if self.is_swapping_blocks else accelerator.device
 
-        from library.runtime.backend import resolve_attention_mode
+        from library.runtime.backend import (
+            needs_rocm_attention_fallback,
+            resolve_attention_mode,
+        )
 
         requested_attn_mode = args.attn_mode
         attn_mode = resolve_attention_mode(requested_attn_mode, torch)
-        if attn_mode != requested_attn_mode:
+        if needs_rocm_attention_fallback(requested_attn_mode, torch):
             logger.warning(
                 "ROCm detected: using PyTorch SDPA instead of CUDA Flash Attention"
             )

--- a/train.py
+++ b/train.py
@@ -452,9 +452,14 @@ class AnimaTrainer:
         loading_dtype = weight_dtype
         loading_device = "cpu" if self.is_swapping_blocks else accelerator.device
 
-        attn_mode = "torch"
-        if args.attn_mode is not None:
-            attn_mode = args.attn_mode
+        from library.runtime.backend import resolve_attention_mode
+
+        requested_attn_mode = args.attn_mode
+        attn_mode = resolve_attention_mode(requested_attn_mode, torch)
+        if attn_mode != requested_attn_mode:
+            logger.warning(
+                "ROCm detected: using PyTorch SDPA instead of CUDA Flash Attention"
+            )
 
         if attn_mode == "flash4":
             # Flash Attention 4 (flash-attention-sm120) is not supported yet.

--- a/uv.lock
+++ b/uv.lock
@@ -2,22 +2,30 @@ version = 1
 revision = 3
 requires-python = "==3.13.*"
 resolution-markers = [
-    "sys_platform == 'win32'",
     "platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "(platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "sys_platform == 'darwin'",
+    "sys_platform == 'win32'",
 ]
 required-markers = [
     "platform_machine == 'x86_64' and sys_platform == 'linux'",
     "platform_machine == 'aarch64' and sys_platform == 'linux'",
     "sys_platform == 'win32'",
 ]
+conflicts = [[
+    { package = "anima-lora", extra = "cuda-windows" },
+    { package = "anima-lora", extra = "rocm-windows" },
+]]
 
 [options]
 prerelease-mode = "allow"
 
 [manifest]
-overrides = [{ name = "numpy", specifier = ">=2.0.0" }]
+overrides = [
+    { name = "numpy", specifier = ">=2.0.0" },
+    { name = "triton", marker = "sys_platform != 'win32'" },
+]
 
 [[package]]
 name = "absl-py"
@@ -34,13 +42,15 @@ version = "1.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "packaging" },
     { name = "psutil" },
     { name = "pyyaml" },
     { name = "safetensors" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "sys_platform != 'darwin'" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0+rocm7.14.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ca/14/787e5498cd062640f0f3d92ef4ae4063174f76f9afd29d13fc52a319daae/accelerate-1.13.0.tar.gz", hash = "sha256:d631b4e0f5b3de4aff2d7e9e6857d164810dfc3237d54d017f075122d057b236", size = 402835, upload-time = "2026-03-04T19:34:12.359Z" }
 wheels = [
@@ -116,7 +126,8 @@ name = "albucore"
 version = "0.0.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "opencv-python-headless" },
     { name = "simsimd" },
     { name = "stringzilla" },
@@ -132,7 +143,8 @@ version = "2.0.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "albucore" },
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "opencv-python-headless" },
     { name = "pydantic" },
     { name = "pyyaml" },
@@ -158,6 +170,70 @@ wheels = [
 ]
 
 [[package]]
+name = "amd-torch-device-gfx12-0"
+version = "2.12.0+rocm7.14.0"
+source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }
+dependencies = [
+    { name = "torch", version = "2.12.0+rocm7.14.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "sys_platform == 'win32'" },
+]
+wheels = [
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/amd_torch_device_gfx12_0-2.12.0%2Brocm7.14.0-cp313-cp313-linux_x86_64.whl" },
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/amd_torch_device_gfx12_0-2.12.0%2Brocm7.14.0-cp313-cp313-win_amd64.whl" },
+]
+
+[[package]]
+name = "amd-torch-device-gfx1200"
+version = "2.12.0+rocm7.14.0"
+source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }
+dependencies = [
+    { name = "rocm-sdk-device-gfx1200", marker = "sys_platform == 'win32'" },
+    { name = "torch", version = "2.12.0+rocm7.14.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "sys_platform == 'win32'" },
+]
+wheels = [
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/amd_torch_device_gfx1200-2.12.0%2Brocm7.14.0-cp313-cp313-linux_x86_64.whl" },
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/amd_torch_device_gfx1200-2.12.0%2Brocm7.14.0-cp313-cp313-win_amd64.whl" },
+]
+
+[[package]]
+name = "amd-torch-device-gfx1201"
+version = "2.12.0+rocm7.14.0"
+source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }
+dependencies = [
+    { name = "rocm-sdk-device-gfx1201", marker = "sys_platform == 'win32'" },
+    { name = "torch", version = "2.12.0+rocm7.14.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "sys_platform == 'win32'" },
+]
+wheels = [
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/amd_torch_device_gfx1201-2.12.0%2Brocm7.14.0-cp313-cp313-linux_x86_64.whl" },
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/amd_torch_device_gfx1201-2.12.0%2Brocm7.14.0-cp313-cp313-win_amd64.whl" },
+]
+
+[[package]]
+name = "amd-torchvision-device-gfx1200"
+version = "0.27.0+rocm7.14.0"
+source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }
+dependencies = [
+    { name = "rocm-sdk-device-gfx1200", marker = "sys_platform == 'win32'" },
+    { name = "torchvision", version = "0.27.0+rocm7.14.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "sys_platform == 'win32'" },
+]
+wheels = [
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/amd_torchvision_device_gfx1200-0.27.0%2Brocm7.14.0-cp313-cp313-linux_x86_64.whl" },
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/amd_torchvision_device_gfx1200-0.27.0%2Brocm7.14.0-cp313-cp313-win_amd64.whl" },
+]
+
+[[package]]
+name = "amd-torchvision-device-gfx1201"
+version = "0.27.0+rocm7.14.0"
+source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }
+dependencies = [
+    { name = "rocm-sdk-device-gfx1201", marker = "sys_platform == 'win32'" },
+    { name = "torchvision", version = "0.27.0+rocm7.14.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "sys_platform == 'win32'" },
+]
+wheels = [
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/amd_torchvision_device_gfx1201-0.27.0%2Brocm7.14.0-cp313-cp313-linux_x86_64.whl" },
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/amd_torchvision_device_gfx1201-0.27.0%2Brocm7.14.0-cp313-cp313-win_amd64.whl" },
+]
+
+[[package]]
 name = "anima-lora"
 version = "0.1.0"
 source = { editable = "." }
@@ -175,19 +251,20 @@ dependencies = [
     { name = "datasets" },
     { name = "diffusers" },
     { name = "einops" },
-    { name = "flash-attn", version = "2.8.3+cu132torch2.12", source = { url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.9.17/flash_attn-2.8.3+cu132torch2.12-cp313-cp313-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "flash-attn", version = "2.8.3+cu132torch2.12", source = { url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.9.22/flash_attn-2.8.3+cu132torch2.12-cp313-cp313-linux_aarch64.whl" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "flash-attn", version = "2.8.3+cu132torch2.12", source = { url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.9.25/flash_attn-2.8.3+cu132torch2.12-cp313-cp313-win_amd64.whl" }, marker = "sys_platform == 'win32'" },
+    { name = "flash-attn", version = "2.8.3+cu132torch2.12", source = { url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.9.17/flash_attn-2.8.3+cu132torch2.12-cp313-cp313-linux_x86_64.whl" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "flash-attn", version = "2.8.3+cu132torch2.12", source = { url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.9.22/flash_attn-2.8.3+cu132torch2.12-cp313-cp313-linux_aarch64.whl" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "huggingface-hub" },
     { name = "imagesize" },
     { name = "kornia" },
     { name = "matplotlib" },
-    { name = "numpy" },
-    { name = "onnxruntime-gpu", version = "1.26.0", source = { url = "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-cuda-13/pypi/download/onnxruntime-gpu/1.26.0/onnxruntime_gpu-1.26.0-cp313-cp313-manylinux_2_34_aarch64.whl" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "onnxruntime-gpu", version = "1.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "onnxruntime-gpu", version = "1.26.0", source = { url = "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-cuda-13/pypi/download/onnxruntime-gpu/1.26.0/onnxruntime_gpu-1.26.0-cp313-cp313-manylinux_2_34_aarch64.whl" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "onnxruntime-gpu", version = "1.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or sys_platform == 'win32' or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "opencv-python" },
     { name = "packaging" },
-    { name = "pillow" },
+    { name = "pillow", version = "12.2.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "pillow", version = "12.3.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "prodigyopt" },
     { name = "psutil" },
     { name = "pycocotools" },
@@ -211,20 +288,25 @@ dependencies = [
     { name = "tensorboard" },
     { name = "toml" },
     { name = "tomlkit" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "sys_platform != 'darwin'" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "torchsde" },
-    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "torchvision", version = "0.27.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "sys_platform != 'darwin'" },
+    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torchvision", version = "0.27.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "tqdm" },
     { name = "transformers" },
-    { name = "triton-windows", marker = "sys_platform == 'win32'" },
     { name = "uv" },
     { name = "voluptuous" },
     { name = "yarl" },
 ]
 
 [package.optional-dependencies]
+cuda-windows = [
+    { name = "flash-attn", version = "2.8.3+cu132torch2.12", source = { url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.9.25/flash_attn-2.8.3+cu132torch2.12-cp313-cp313-win_amd64.whl" }, marker = "sys_platform == 'win32'" },
+    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "sys_platform == 'win32'" },
+    { name = "torchvision", version = "0.27.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "sys_platform == 'win32'" },
+    { name = "triton-windows", marker = "sys_platform == 'win32'" },
+]
 dev = [
     { name = "pytest" },
     { name = "pytest-timeout" },
@@ -232,6 +314,11 @@ dev = [
 ]
 gui = [
     { name = "pyside6" },
+]
+rocm-windows = [
+    { name = "torch", version = "2.12.0+rocm7.14.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, extra = ["device-gfx1200", "device-gfx1201"], marker = "(sys_platform == 'win32' and extra == 'extra-10-anima-lora-rocm-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torchvision", version = "0.27.0+rocm7.14.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, extra = ["device-gfx1200", "device-gfx1201"], marker = "(sys_platform == 'win32' and extra == 'extra-10-anima-lora-rocm-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "triton-windows", marker = "sys_platform == 'win32'" },
 ]
 
 [package.dev-dependencies]
@@ -275,7 +362,7 @@ requires-dist = [
     { name = "einops", specifier = ">=0.7.0" },
     { name = "flash-attn", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'", url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.9.22/flash_attn-2.8.3+cu132torch2.12-cp313-cp313-linux_aarch64.whl" },
     { name = "flash-attn", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.9.17/flash_attn-2.8.3+cu132torch2.12-cp313-cp313-linux_x86_64.whl" },
-    { name = "flash-attn", marker = "sys_platform == 'win32'", url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.9.25/flash_attn-2.8.3+cu132torch2.12-cp313-cp313-win_amd64.whl" },
+    { name = "flash-attn", marker = "sys_platform == 'win32' and extra == 'cuda-windows'", url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.9.25/flash_attn-2.8.3+cu132torch2.12-cp313-cp313-win_amd64.whl" },
     { name = "huggingface-hub", specifier = ">=1.9.0" },
     { name = "imagesize", specifier = ">=1.4.1" },
     { name = "kornia", specifier = ">=0.8.2" },
@@ -313,17 +400,24 @@ requires-dist = [
     { name = "tensorboard" },
     { name = "toml", specifier = ">=0.10.2" },
     { name = "tomlkit", specifier = ">=0.13" },
-    { name = "torch", specifier = ">=2.12.0,<2.13" },
+    { name = "torch", marker = "sys_platform != 'darwin' and sys_platform != 'win32'", specifier = ">=2.12.0,<2.13", index = "https://download.pytorch.org/whl/cu132" },
+    { name = "torch", marker = "sys_platform == 'darwin'", specifier = ">=2.12.0,<2.13" },
+    { name = "torch", marker = "sys_platform == 'win32' and extra == 'cuda-windows'", specifier = "==2.12.0+cu132", index = "https://download.pytorch.org/whl/cu132", conflict = { package = "anima-lora", extra = "cuda-windows" } },
+    { name = "torch", extras = ["device-gfx1200", "device-gfx1201"], marker = "sys_platform == 'win32' and extra == 'rocm-windows'", specifier = "==2.12.0+rocm7.14.0", index = "https://repo.amd.com/rocm/whl-multi-arch/", conflict = { package = "anima-lora", extra = "rocm-windows" } },
     { name = "torchsde", specifier = ">=0.2.6" },
-    { name = "torchvision", specifier = ">=0.27.0,<0.28" },
+    { name = "torchvision", marker = "sys_platform != 'darwin' and sys_platform != 'win32'", specifier = ">=0.27.0,<0.28", index = "https://download.pytorch.org/whl/cu132" },
+    { name = "torchvision", marker = "sys_platform == 'darwin'", specifier = ">=0.27.0,<0.28" },
+    { name = "torchvision", marker = "sys_platform == 'win32' and extra == 'cuda-windows'", specifier = "==0.27.0+cu132", index = "https://download.pytorch.org/whl/cu132", conflict = { package = "anima-lora", extra = "cuda-windows" } },
+    { name = "torchvision", extras = ["device-gfx1200", "device-gfx1201"], marker = "sys_platform == 'win32' and extra == 'rocm-windows'", specifier = "==0.27.0+rocm7.14.0", index = "https://repo.amd.com/rocm/whl-multi-arch/", conflict = { package = "anima-lora", extra = "rocm-windows" } },
     { name = "tqdm" },
     { name = "transformers", specifier = ">=5.10.1" },
-    { name = "triton-windows", marker = "sys_platform == 'win32'", specifier = ">=3.7.0,<3.8.0" },
+    { name = "triton-windows", marker = "sys_platform == 'win32' and extra == 'cuda-windows'", specifier = ">=3.7.0,<3.8.0" },
+    { name = "triton-windows", marker = "sys_platform == 'win32' and extra == 'rocm-windows'", specifier = ">=3.7.0,<3.8.0" },
     { name = "uv", specifier = ">=0.11.7" },
     { name = "voluptuous", specifier = ">=0.15.2" },
     { name = "yarl", specifier = ">=1.23.0" },
 ]
-provides-extras = ["gui", "dev"]
+provides-extras = ["gui", "cuda-windows", "rocm-windows", "dev"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "markdownify" }]
@@ -460,11 +554,14 @@ name = "bitsandbytes"
 version = "0.49.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "sys_platform != 'darwin'" },
-    { name = "packaging", marker = "sys_platform != 'darwin'" },
-    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "sys_platform != 'darwin'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform == 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "packaging", marker = "sys_platform != 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0+rocm7.14.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/7d/f1fe0992334b18cd8494f89aeec1dcc674635584fcd9f115784fea3a1d05/bitsandbytes-0.49.2-py3-none-macosx_14_0_arm64.whl", hash = "sha256:87be5975edeac5396d699ecbc39dfc47cf2c026daaf2d5852a94368611a6823f", size = 131940, upload-time = "2026-02-16T21:26:04.572Z" },
     { url = "https://files.pythonhosted.org/packages/29/71/acff7af06c818664aa87ff73e17a52c7788ad746b72aea09d3cb8e424348/bitsandbytes-0.49.2-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:2fc0830c5f7169be36e60e11f2be067c8f812dfcb829801a8703735842450750", size = 31442815, upload-time = "2026-02-16T21:26:06.783Z" },
     { url = "https://files.pythonhosted.org/packages/19/57/3443d6f183436fbdaf5000aac332c4d5ddb056665d459244a5608e98ae92/bitsandbytes-0.49.2-py3-none-manylinux_2_24_x86_64.whl", hash = "sha256:54b771f06e1a3c73af5c7f16ccf0fc23a846052813d4b008d10cb6e017dd1c8c", size = 60651714, upload-time = "2026-02-16T21:26:11.579Z" },
     { url = "https://files.pythonhosted.org/packages/b6/d4/501655842ad6771fb077f576d78cbedb5445d15b1c3c91343ed58ca46f0e/bitsandbytes-0.49.2-py3-none-win_amd64.whl", hash = "sha256:2e0ddd09cd778155388023cbe81f00afbb7c000c214caef3ce83386e7144df7d", size = 55372289, upload-time = "2026-02-16T21:26:16.267Z" },
@@ -550,7 +647,7 @@ name = "click"
 version = "8.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
 wheels = [
@@ -560,9 +657,10 @@ wheels = [
 [[package]]
 name = "colorama"
 version = "0.4.6"
-source = { registry = "https://download.pytorch.org/whl/cu132" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
-    { url = "https://download.pytorch.org/whl/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", upload-time = "2023-10-05T23:50:34Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
 ]
 
 [[package]]
@@ -624,7 +722,8 @@ name = "contourpy"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -661,16 +760,20 @@ dependencies = [
     { name = "filelock" },
     { name = "huggingface-hub" },
     { name = "importlib-metadata" },
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "opencv-python-headless" },
-    { name = "pillow" },
+    { name = "pillow", version = "12.2.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "pillow", version = "12.3.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "scikit-image" },
     { name = "scipy" },
     { name = "timm" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "sys_platform != 'darwin'" },
-    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "torchvision", version = "0.27.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "sys_platform != 'darwin'" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0+rocm7.14.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torchvision", version = "0.27.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torchvision", version = "0.27.0+rocm7.14.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/14/ad/2eb8cd9a8e17e35b9e5d39ad29afdde8fe810bda85e6e59117050519955d/controlnet_aux-0.0.10.tar.gz", hash = "sha256:31dc265a54448bdcee033a130b47423c80587fa35ccac752113af1b4d48f5183", size = 215016, upload-time = "2025-05-08T10:38:30.845Z" }
 wheels = [
@@ -701,11 +804,12 @@ name = "cuda-bindings"
 version = "13.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
+    { name = "cuda-pathfinder", marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/93/eef988860a3ca985f82c4f3174fc0cdd94e07331ba9a92e8e064c260337f/cuda_bindings-13.2.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6629ca2df6f795b784752409bcaedbd22a7a651b74b56a165ebc0c9dcbd504d0", size = 5614610, upload-time = "2026-03-11T00:12:50.337Z" },
     { url = "https://files.pythonhosted.org/packages/18/23/6db3aba46864aee357ab2415135b3fe3da7e9f1fa0221fa2a86a5968099c/cuda_bindings-13.2.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7dca0da053d3b4cc4869eff49c61c03f3c5dbaa0bcd712317a358d5b8f3f385d", size = 6149914, upload-time = "2026-03-11T00:12:52.374Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/84/d3b6220b51cbc02ca14db7387e97445126b4ff5125aaa6c5dd7dcb75e679/cuda_bindings-13.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:8cebe3ce4aeeca5af9c490e175f76c4b569bbf4a35a62294b777bc77bf7ac4d8", size = 5796512, upload-time = "2026-03-11T00:12:54.483Z" },
 ]
 
 [[package]]
@@ -719,50 +823,50 @@ wheels = [
 [[package]]
 name = "cuda-toolkit"
 version = "13.2.1"
-source = { registry = "https://download.pytorch.org/whl/cu132" }
+source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://pypi.nvidia.com/cuda-toolkit/cuda_toolkit-13.2.1-py2.py3-none-any.whl", hash = "sha256:646d0e3668ce6f78f2312bb9cc0f668b9cbfcbef187eaa6a39eb2ea6dbec2a31" },
+    { url = "https://files.pythonhosted.org/packages/bd/6a/f79c134fa8e6d5fe028584933be063ce7961b1a85ce217f261cdda176e48/cuda_toolkit-13.2.1-py2.py3-none-any.whl", hash = "sha256:646d0e3668ce6f78f2312bb9cc0f668b9cbfcbef187eaa6a39eb2ea6dbec2a31", size = 2612, upload-time = "2026-04-14T01:10:36.163Z" },
 ]
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cublas", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-runtime", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cufft", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cufile", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-cupti", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-curand", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cublas", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "nvidia-cusolver", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvtx", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 
 [[package]]
@@ -785,7 +889,8 @@ dependencies = [
     { name = "httpx" },
     { name = "huggingface-hub" },
     { name = "multiprocess" },
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "packaging" },
     { name = "pandas" },
     { name = "pyarrow" },
@@ -808,8 +913,10 @@ dependencies = [
     { name = "httpx" },
     { name = "huggingface-hub" },
     { name = "importlib-metadata" },
-    { name = "numpy" },
-    { name = "pillow" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "pillow", version = "12.2.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "pillow", version = "12.3.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "regex" },
     { name = "requests" },
     { name = "safetensors" },
@@ -871,14 +978,18 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filterpy" },
     { name = "numba" },
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "opencv-python" },
-    { name = "pillow" },
+    { name = "pillow", version = "12.2.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "pillow", version = "12.3.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "scipy" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "sys_platform != 'darwin'" },
-    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "torchvision", version = "0.27.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "sys_platform != 'darwin'" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0+rocm7.14.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torchvision", version = "0.27.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torchvision", version = "0.27.0+rocm7.14.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "tqdm" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e1/93/c820cd2c6315b635934770808e0b01ed4db257ec33bcf803909dcf4bce15/facexlib-0.3.0.tar.gz", hash = "sha256:7ae784a520eb52e05583e8bf9f68f77f45083239ac754d646d635017b49e7763", size = 1066362, upload-time = "2023-04-15T06:51:59.169Z" }
@@ -889,10 +1000,10 @@ wheels = [
 [[package]]
 name = "filelock"
 version = "3.25.2"
-source = { registry = "https://download.pytorch.org/whl/cu132" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/b8/00651a0f559862f3bb7d6f7477b192afe3f583cc5e26403b44e59a55ab34/filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/b8/00651a0f559862f3bb7d6f7477b192afe3f583cc5e26403b44e59a55ab34/filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694", size = 40480, upload-time = "2026-03-11T20:45:38.487Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70" },
+    { url = "https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70", size = 26759, upload-time = "2026-03-11T20:45:37.437Z" },
 ]
 
 [[package]]
@@ -901,7 +1012,8 @@ version = "1.4.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "matplotlib" },
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "scipy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f6/1d/ac8914360460fafa1990890259b7fa5ef7ba4cd59014e782e4ab3ab144d8/filterpy-1.4.5.zip", hash = "sha256:4f2a4d39e4ea601b9ab42b2db08b5918a9538c168cff1c6895ae26646f3d73b1", size = 177985, upload-time = "2018-10-10T22:38:24.63Z" }
@@ -914,8 +1026,8 @@ resolution-markers = [
     "platform_machine == 'x86_64' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "einops", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "einops", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 wheels = [
     { url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.9.17/flash_attn-2.8.3+cu132torch2.12-cp313-cp313-linux_x86_64.whl", hash = "sha256:f42938baa6928477426435bd479fe62b27b12b9fe0cc54019e43a3637c1a5cf6" },
@@ -932,11 +1044,11 @@ name = "flash-attn"
 version = "2.8.3+cu132torch2.12"
 source = { url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.9.22/flash_attn-2.8.3+cu132torch2.12-cp313-cp313-linux_aarch64.whl" }
 resolution-markers = [
-    "(platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "platform_machine == 'aarch64' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "einops", marker = "(platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')" },
-    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "(platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')" },
+    { name = "einops", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 wheels = [
     { url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.9.22/flash_attn-2.8.3+cu132torch2.12-cp313-cp313-linux_aarch64.whl", hash = "sha256:34304ebe2047de9ec400baf7633431033602a05e5297a32f23d6bc2d674254aa" },
@@ -1038,10 +1150,10 @@ wheels = [
 [[package]]
 name = "fsspec"
 version = "2026.2.0"
-source = { registry = "https://download.pytorch.org/whl/cu132" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/7c/f60c259dcbf4f0c47cc4ddb8f7720d2dcdc8888c8e5ad84c73ea4531cc5b/fsspec-2026.2.0.tar.gz", hash = "sha256:6544e34b16869f5aacd5b90bdf1a71acb37792ea3ddf6125ee69a22a53fb8bff" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/7c/f60c259dcbf4f0c47cc4ddb8f7720d2dcdc8888c8e5ad84c73ea4531cc5b/fsspec-2026.2.0.tar.gz", hash = "sha256:6544e34b16869f5aacd5b90bdf1a71acb37792ea3ddf6125ee69a22a53fb8bff", size = 313441, upload-time = "2026-02-05T21:50:53.743Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl", hash = "sha256:98de475b5cb3bd66bedd5c4679e87b4fdfe1a3bf4d707b151b3c07e58c9a2437" },
+    { url = "https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl", hash = "sha256:98de475b5cb3bd66bedd5c4679e87b4fdfe1a3bf4d707b151b3c07e58c9a2437", size = 202505, upload-time = "2026-02-05T21:50:51.819Z" },
 ]
 
 [package.optional-dependencies]
@@ -1192,7 +1304,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "httpx" },
     { name = "packaging" },
     { name = "pyyaml" },
@@ -1228,8 +1340,10 @@ name = "imageio"
 version = "2.37.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "pillow" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "pillow", version = "12.2.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "pillow", version = "12.3.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b1/84/93bcd1300216ea50811cee96873b84a1bebf8d0489ffaf7f2a3756bab866/imageio-2.37.3.tar.gz", hash = "sha256:bbb37efbfc4c400fcd534b367b91fcd66d5da639aaa138034431a1c5e0a41451", size = 389673, upload-time = "2026-03-09T11:31:12.573Z" }
 wheels = [
@@ -1280,12 +1394,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/72/73/b3d451dfc523756cf
 [[package]]
 name = "jinja2"
 version = "3.1.6"
-source = { registry = "https://download.pytorch.org/whl/cu132" }
+source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }
 dependencies = [
     { name = "markupsafe" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/jinja2-3.1.6-py3-none-any.whl", upload-time = "2025-10-14T18:38:59Z" },
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/jinja2-3.1.6-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -1353,8 +1467,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "kornia-rs" },
     { name = "packaging" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "sys_platform != 'darwin'" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0+rocm7.14.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c6/e6/45e757d4924176e4d4e111e10effaab7db382313243e0188a06805010073/kornia-0.8.2.tar.gz", hash = "sha256:5411b2ce0dd909d1608016308cd68faeef90f88c47f47e8ecd40553fd4d8b937", size = 667151, upload-time = "2025-11-08T12:10:03.042Z" }
 wheels = [
@@ -1422,8 +1537,8 @@ name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
 wheels = [
@@ -1444,12 +1559,15 @@ name = "lpips"
 version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "scipy" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "sys_platform != 'darwin'" },
-    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "torchvision", version = "0.27.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "sys_platform != 'darwin'" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0+rocm7.14.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torchvision", version = "0.27.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torchvision", version = "0.27.0+rocm7.14.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "tqdm" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e8/2d/4b8148d32f5bd461eb7d5daa54fcc998f86eaa709a57f4ef6aa4c62f024f/lpips-0.1.4.tar.gz", hash = "sha256:3846331df6c69688aec3d300a5eeef6c529435bc8460bd58201c3d62e56188fa", size = 18029, upload-time = "2021-08-25T22:10:32.803Z" }
@@ -1506,20 +1624,29 @@ wheels = [
 [[package]]
 name = "markupsafe"
 version = "3.0.2"
-source = { registry = "https://download.pytorch.org/whl/cu132" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0", size = 20537, upload-time = "2024-10-18T15:21:54.129Z" }
 wheels = [
-    { url = "https://download.pytorch.org/whl/MarkupSafe-3.0.2-cp313-cp313-macosx_10_13_universal2.whl", upload-time = "2026-02-19T22:23:11Z" },
-    { url = "https://download.pytorch.org/whl/MarkupSafe-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", upload-time = "2026-02-19T22:23:11Z" },
-    { url = "https://download.pytorch.org/whl/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", upload-time = "2026-02-19T22:23:13Z" },
-    { url = "https://download.pytorch.org/whl/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", upload-time = "2026-02-19T22:23:13Z" },
-    { url = "https://download.pytorch.org/whl/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", upload-time = "2026-02-19T22:23:13Z" },
-    { url = "https://download.pytorch.org/whl/MarkupSafe-3.0.2-cp313-cp313-win_amd64.whl", upload-time = "2026-02-19T22:23:13Z" },
-    { url = "https://download.pytorch.org/whl/MarkupSafe-3.0.2-cp313-cp313t-macosx_10_13_universal2.whl", upload-time = "2026-02-19T22:23:13Z" },
-    { url = "https://download.pytorch.org/whl/MarkupSafe-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", upload-time = "2026-02-19T22:23:14Z" },
-    { url = "https://download.pytorch.org/whl/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", upload-time = "2026-02-19T22:23:14Z" },
-    { url = "https://download.pytorch.org/whl/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", upload-time = "2026-02-19T22:23:14Z" },
-    { url = "https://download.pytorch.org/whl/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", upload-time = "2026-02-19T22:23:14Z" },
-    { url = "https://download.pytorch.org/whl/MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", upload-time = "2026-02-19T22:23:15Z" },
+    { url = "https://files.pythonhosted.org/packages/83/0e/67eb10a7ecc77a0c2bbe2b0235765b98d164d81600746914bebada795e97/MarkupSafe-3.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ba9527cdd4c926ed0760bc301f6728ef34d841f405abf9d4f959c478421e4efd", size = 14274, upload-time = "2024-10-18T15:21:24.577Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/6d/9409f3684d3335375d04e5f05744dfe7e9f120062c9857df4ab490a1031a/MarkupSafe-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f8b3d067f2e40fe93e1ccdd6b2e1d16c43140e76f02fb1319a05cf2b79d99430", size = 12352, upload-time = "2024-10-18T15:21:25.382Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f5/6eadfcd3885ea85fe2a7c128315cc1bb7241e1987443d78c8fe712d03091/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:569511d3b58c8791ab4c2e1285575265991e6d8f8700c7be0e88f86cb0672094", size = 24122, upload-time = "2024-10-18T15:21:26.199Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/91/96cf928db8236f1bfab6ce15ad070dfdd02ed88261c2afafd4b43575e9e9/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15ab75ef81add55874e7ab7055e9c397312385bd9ced94920f2802310c930396", size = 23085, upload-time = "2024-10-18T15:21:27.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/cf/c9d56af24d56ea04daae7ac0940232d31d5a8354f2b457c6d856b2057d69/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f3818cb119498c0678015754eba762e0d61e5b52d34c8b13d770f0719f7b1d79", size = 22978, upload-time = "2024-10-18T15:21:27.846Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/9f/8619835cd6a711d6272d62abb78c033bda638fdc54c4e7f4272cf1c0962b/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cdb82a876c47801bb54a690c5ae105a46b392ac6099881cdfb9f6e95e4014c6a", size = 24208, upload-time = "2024-10-18T15:21:28.744Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/bf/176950a1792b2cd2102b8ffeb5133e1ed984547b75db47c25a67d3359f77/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:cabc348d87e913db6ab4aa100f01b08f481097838bdddf7c7a84b7575b7309ca", size = 23357, upload-time = "2024-10-18T15:21:29.545Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/4f/9a02c1d335caabe5c4efb90e1b6e8ee944aa245c1aaaab8e8a618987d816/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:444dcda765c8a838eaae23112db52f1efaf750daddb2d9ca300bcae1039adc5c", size = 23344, upload-time = "2024-10-18T15:21:30.366Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/55/c271b57db36f748f0e04a759ace9f8f759ccf22b4960c270c78a394f58be/MarkupSafe-3.0.2-cp313-cp313-win32.whl", hash = "sha256:bcf3e58998965654fdaff38e58584d8937aa3096ab5354d493c77d1fdd66d7a1", size = 15101, upload-time = "2024-10-18T15:21:31.207Z" },
+    { url = "https://files.pythonhosted.org/packages/29/88/07df22d2dd4df40aba9f3e402e6dc1b8ee86297dddbad4872bd5e7b0094f/MarkupSafe-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:e6a2a455bd412959b57a172ce6328d2dd1f01cb2135efda2e4576e8a23fa3b0f", size = 15603, upload-time = "2024-10-18T15:21:32.032Z" },
+    { url = "https://files.pythonhosted.org/packages/62/6a/8b89d24db2d32d433dffcd6a8779159da109842434f1dd2f6e71f32f738c/MarkupSafe-3.0.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b5a6b3ada725cea8a5e634536b1b01c30bcdcd7f9c6fff4151548d5bf6b3a36c", size = 14510, upload-time = "2024-10-18T15:21:33.625Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/06/a10f955f70a2e5a9bf78d11a161029d278eeacbd35ef806c3fd17b13060d/MarkupSafe-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a904af0a6162c73e3edcb969eeeb53a63ceeb5d8cf642fade7d39e7963a22ddb", size = 12486, upload-time = "2024-10-18T15:21:34.611Z" },
+    { url = "https://files.pythonhosted.org/packages/34/cf/65d4a571869a1a9078198ca28f39fba5fbb910f952f9dbc5220afff9f5e6/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aa4e5faecf353ed117801a068ebab7b7e09ffb6e1d5e412dc852e0da018126c", size = 25480, upload-time = "2024-10-18T15:21:35.398Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e3/90e9651924c430b885468b56b3d597cabf6d72be4b24a0acd1fa0e12af67/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0ef13eaeee5b615fb07c9a7dadb38eac06a0608b41570d8ade51c56539e509d", size = 23914, upload-time = "2024-10-18T15:21:36.231Z" },
+    { url = "https://files.pythonhosted.org/packages/66/8c/6c7cf61f95d63bb866db39085150df1f2a5bd3335298f14a66b48e92659c/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d16a81a06776313e817c951135cf7340a3e91e8c1ff2fac444cfd75fffa04afe", size = 23796, upload-time = "2024-10-18T15:21:37.073Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/35/cbe9238ec3f47ac9a7c8b3df7a808e7cb50fe149dc7039f5f454b3fba218/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6381026f158fdb7c72a168278597a5e3a5222e83ea18f543112b2662a9b699c5", size = 25473, upload-time = "2024-10-18T15:21:37.932Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/32/7621a4382488aa283cc05e8984a9c219abad3bca087be9ec77e89939ded9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:3d79d162e7be8f996986c064d1c7c817f6df3a77fe3d6859f6f9e7be4b8c213a", size = 24114, upload-time = "2024-10-18T15:21:39.799Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/80/0985960e4b89922cb5a0bac0ed39c5b96cbc1a536a99f30e8c220a996ed9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9", size = 24098, upload-time = "2024-10-18T15:21:40.813Z" },
+    { url = "https://files.pythonhosted.org/packages/82/78/fedb03c7d5380df2427038ec8d973587e90561b2d90cd472ce9254cf348b/MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6", size = 15208, upload-time = "2024-10-18T15:21:41.814Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/65/6079a46068dfceaeabb5dcad6d674f5f5c61a6fa5673746f42a9f4c233b3/MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f", size = 15739, upload-time = "2024-10-18T15:21:42.784Z" },
 ]
 
 [[package]]
@@ -1531,9 +1658,11 @@ dependencies = [
     { name = "cycler" },
     { name = "fonttools" },
     { name = "kiwisolver" },
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "packaging" },
-    { name = "pillow" },
+    { name = "pillow", version = "12.2.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "pillow", version = "12.3.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "pyparsing" },
     { name = "python-dateutil" },
 ]
@@ -1583,10 +1712,9 @@ wheels = [
 [[package]]
 name = "mpmath"
 version = "1.3.0"
-source = { registry = "https://download.pytorch.org/whl/cu132" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f" }
+source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c" },
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/mpmath-1.3.0-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -1662,10 +1790,9 @@ wheels = [
 [[package]]
 name = "networkx"
 version = "3.6.1"
-source = { registry = "https://download.pytorch.org/whl/cu132" }
-sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509" }
+source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762" },
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/networkx-3.6.1-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -1683,7 +1810,8 @@ version = "0.65.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "llvmlite" },
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f6/c5/db2ac3685833d626c0dcae6bd2330cd68433e1fd248d15f70998160d3ad7/numba-0.65.1.tar.gz", hash = "sha256:19357146c32fe9ed25059ab915e8465fb13951cf6b0aace3826b76886373ab23", size = 2765600, upload-time = "2026-04-24T02:02:56.551Z" }
 wheels = [
@@ -1696,182 +1824,204 @@ wheels = [
 [[package]]
 name = "numpy"
 version = "2.4.4"
-source = { registry = "https://download.pytorch.org/whl/cu132" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0" }
+source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }
+resolution-markers = [
+    "platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "sys_platform == 'darwin'",
+    "sys_platform == 'win32'",
+]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/1d/d0a583ce4fefcc3308806a749a536c201ed6b5ad6e1322e227ee4848979d/numpy-2.4.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:08f2e31ed5e6f04b118e49821397f12767934cfdd12a1ce86a058f91e004ee50" },
-    { url = "https://files.pythonhosted.org/packages/c1/62/2b7a48fbb745d344742c0277f01286dead15f3f68e4f359fbfcf7b48f70f/numpy-2.4.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e823b8b6edc81e747526f70f71a9c0a07ac4e7ad13020aa736bb7c9d67196115" },
-    { url = "https://files.pythonhosted.org/packages/e5/87/499737bfba066b4a3bebff24a8f1c5b2dee410b209bc6668c9be692580f0/numpy-2.4.4-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4a19d9dba1a76618dd86b164d608566f393f8ec6ac7c44f0cc879011c45e65af" },
-    { url = "https://files.pythonhosted.org/packages/cd/da/464d551604320d1491bc345efed99b4b7034143a85787aab78d5691d5a0e/numpy-2.4.4-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:d2a8490669bfe99a233298348acc2d824d496dee0e66e31b66a6022c2ad74a5c" },
-    { url = "https://files.pythonhosted.org/packages/7d/90/8d23e3b0dafd024bf31bdec225b3bb5c2dbfa6912f8a53b8659f21216cbf/numpy-2.4.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45dbed2ab436a9e826e302fcdcbe9133f9b0006e5af7168afb8963a6520da103" },
-    { url = "https://files.pythonhosted.org/packages/d1/73/a9d864e42a01896bb5974475438f16086be9ba1f0d19d0bb7a07427c4a8b/numpy-2.4.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c901b15172510173f5cb310eae652908340f8dede90fff9e3bf6c0d8dfd92f83" },
-    { url = "https://files.pythonhosted.org/packages/34/fb/14570d65c3bde4e202a031210475ae9cde9b7686a2e7dc97ee67d2833b35/numpy-2.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:99d838547ace2c4aace6c4f76e879ddfe02bb58a80c1549928477862b7a6d6ed" },
-    { url = "https://files.pythonhosted.org/packages/8a/77/2ba9d87081fd41f6d640c83f26fb7351e536b7ce6dd9061b6af5904e8e46/numpy-2.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0aec54fd785890ecca25a6003fd9a5aed47ad607bbac5cd64f836ad8666f4959" },
-    { url = "https://files.pythonhosted.org/packages/a2/23/52666c9a41708b0853fa3b1a12c90da38c507a3074883823126d4e9d5b30/numpy-2.4.4-cp313-cp313-win32.whl", hash = "sha256:07077278157d02f65c43b1b26a3886bce886f95d20aabd11f87932750dfb14ed" },
-    { url = "https://files.pythonhosted.org/packages/57/fb/48649b4971cde70d817cf97a2a2fdc0b4d8308569f1dd2f2611959d2e0cf/numpy-2.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:5c70f1cc1c4efbe316a572e2d8b9b9cc44e89b95f79ca3331553fbb63716e2bf" },
-    { url = "https://files.pythonhosted.org/packages/ba/d8/11490cddd564eb4de97b4579ef6bfe6a736cc07e94c1598590ae25415e01/numpy-2.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:ef4059d6e5152fa1a39f888e344c73fdc926e1b2dd58c771d67b0acfbf2aa67d" },
-    { url = "https://files.pythonhosted.org/packages/99/5d/dab4339177a905aad3e2221c915b35202f1ec30d750dd2e5e9d9a72b804b/numpy-2.4.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4bbc7f303d125971f60ec0aaad5e12c62d0d2c925f0ab1273debd0e4ba37aba5" },
-    { url = "https://files.pythonhosted.org/packages/eb/e4/0564a65e7d3d97562ed6f9b0fd0fb0a6f559ee444092f105938b50043876/numpy-2.4.4-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:4d6d57903571f86180eb98f8f0c839fa9ebbfb031356d87f1361be91e433f5b7" },
-    { url = "https://files.pythonhosted.org/packages/29/8d/35a3a6ce5ad371afa58b4700f1c820f8f279948cca32524e0a695b0ded83/numpy-2.4.4-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:4636de7fd195197b7535f231b5de9e4b36d2c440b6e566d2e4e4746e6af0ca93" },
-    { url = "https://files.pythonhosted.org/packages/f4/da/477731acbd5a58a946c736edfdabb2ac5b34c3d08d1ba1a7b437fa0884df/numpy-2.4.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ad2e2ef14e0b04e544ea2fa0a36463f847f113d314aa02e5b402fdf910ef309e" },
-    { url = "https://files.pythonhosted.org/packages/e6/db/338535d9b152beabeb511579598418ba0212ce77cf9718edd70262cc4370/numpy-2.4.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a285b3b96f951841799528cd1f4f01cd70e7e0204b4abebac9463eecfcf2a40" },
-    { url = "https://files.pythonhosted.org/packages/e2/a9/ad248e8f58beb7a0219b413c9c7d8151c5d285f7f946c3e26695bdbbe2df/numpy-2.4.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f8474c4241bc18b750be2abea9d7a9ec84f46ef861dbacf86a4f6e043401f79e" },
-    { url = "https://files.pythonhosted.org/packages/b5/1a/3b88ccd3694681356f70da841630e4725a7264d6a885c8d442a697e1146b/numpy-2.4.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4e874c976154687c1f71715b034739b45c7711bec81db01914770373d125e392" },
-    { url = "https://files.pythonhosted.org/packages/c2/c9/fcfd5d0639222c6eac7f304829b04892ef51c96a75d479214d77e3ce6e33/numpy-2.4.4-cp313-cp313t-win32.whl", hash = "sha256:9c585a1790d5436a5374bac930dad6ed244c046ed91b2b2a3634eb2971d21008" },
-    { url = "https://files.pythonhosted.org/packages/d5/e3/3938a61d1c538aaec8ed6fd6323f57b0c2d2d2219512434c5c878db76553/numpy-2.4.4-cp313-cp313t-win_amd64.whl", hash = "sha256:93e15038125dc1e5345d9b5b68aa7f996ec33b98118d18c6ca0d0b7d6198b7e8" },
-    { url = "https://files.pythonhosted.org/packages/97/6a/7e345032cc60501721ef94e0e30b60f6b0bd601f9174ebd36389a2b86d40/numpy-2.4.4-cp313-cp313t-win_arm64.whl", hash = "sha256:0dfd3f9d3adbe2920b68b5cd3d51444e13a10792ec7154cd0a2f6e74d4ab3233" },
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/numpy-2.4.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/numpy-2.4.4-cp313-cp313-win_amd64.whl" },
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/numpy-2.4.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/numpy-2.4.4-cp313-cp313t-win_amd64.whl" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "platform_machine == 'aarch64' and sys_platform == 'linux'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/80/db0b4559e57ec36362bedbb05530a87fafbcb6067708c946967a41d449e7/numpy-2.5.2.tar.gz", hash = "sha256:d482d171c406ae88c5b19cad3b6a1c4c5209f886ab74bc44c2c865c23f52d860", size = 20773161, upload-time = "2026-08-09T13:48:27.962Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/d2/6b24738a0ef4557d189b150046cd07823c50e4273e8aebd651222e24306f/numpy-2.5.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8e4cb9a754c8a0c62eaa88273a5fba3391f4a610d1dee893c0755da31c083f15", size = 16886595, upload-time = "2026-08-09T13:45:27.323Z" },
+    { url = "https://files.pythonhosted.org/packages/65/60/f2d208d366f263f39c6e69ed309290717aab41078b6d04c9be2a84fa2a07/numpy-2.5.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:52c808f96484f5571a5cc863775ce50247c17dfb3b0361f8ed6b4b0456f80080", size = 11896845, upload-time = "2026-08-09T13:45:31.638Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/79/81e0bf24f4d020a2b1d5cd297a9f60c3f24eeb116f9bba5870443f7b6a4a/numpy-2.5.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:29d81e97f668489cba8ebfd796b9bdd453525d35dd9e162e2daec94bf3fc7740", size = 5343880, upload-time = "2026-08-09T13:45:34.373Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/cc/e3141cf06d1a8a2c7e107543fe1269c1d1af760d4d683c0794a4ee1127c2/numpy-2.5.2-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:afb3f0632d6b2e3ba04dbce8d1e48d321b369138b73830b5ca371a0e8d479d56", size = 6682264, upload-time = "2026-08-09T13:45:36.7Z" },
+    { url = "https://files.pythonhosted.org/packages/29/f1/2a64a307d92c5d98f5255a4014eb43bb6103ee477087b61ecae44a3aa9b9/numpy-2.5.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0aadf13b60048d501e05fa699efaf7734e2494f3498a4c2a5521d822640324f3", size = 15609566, upload-time = "2026-08-09T13:45:39.518Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/44/59a1eb68e773c4098d107ef34a0dbdeca501d72ffcfbff9a7707343921ce/numpy-2.5.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29b86ff8a6cc556b47ec6b64b194815cc80e6bf5eedcc6cddfd65318cb0b4eee", size = 16709995, upload-time = "2026-08-09T13:45:43.661Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/4c/3e54d4ddbc359a1295f8b633e8106bcd4d7d4a206e82df051bdfb3058755/numpy-2.5.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6950c4b7dd562453090548ba7f5da7e59f57f85663f15d5dcc60e249192f7e59", size = 16972511, upload-time = "2026-08-09T13:45:47.094Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/9f/02e371638ebf19b66d46231e4be52999e87f32d1961b113bc45656608b22/numpy-2.5.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b9727f472d2f3888053b8a75ab0cb94745a9de224bb5846dbadc0092101bc71d", size = 18465609, upload-time = "2026-08-09T13:45:50.808Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ae/ad6645abc7a3510fe48e8ea1ab4598166f500057ef4ebf38bfad4f1577de/numpy-2.5.2-cp313-cp313-win32.whl", hash = "sha256:4f9744f9fbdcea0bc552e8f19e1f141f811a3f9bc2be2cc6e86d982cab23e3f4", size = 6070204, upload-time = "2026-08-09T13:45:54.111Z" },
+    { url = "https://files.pythonhosted.org/packages/15/20/f3489f86d81ea460b2bcdceaed094142ca6579f6be0ec527b781d39afe68/numpy-2.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:85aaccb24182c25df891ad0ec333585967e115269d5f1b17f2c9ae005bc96657", size = 12460532, upload-time = "2026-08-09T13:45:57.167Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/21/35b31dde1b283b79de828b80f876afd8c94e28fe1e9c375f89e261cc4c0d/numpy-2.5.2-cp313-cp313-win_arm64.whl", hash = "sha256:bd68ece1553d2023c09a4226d9e41c586ad2d20594d1a456186c33513d2cb3f2", size = 10396725, upload-time = "2026-08-09T13:46:00.478Z" },
 ]
 
 [[package]]
 name = "nvidia-cublas"
 version = "13.4.0.1"
-source = { registry = "https://download.pytorch.org/whl/cu132" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
+    { name = "nvidia-cuda-nvrtc", marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 wheels = [
-    { url = "https://pypi.nvidia.com/nvidia-cublas/nvidia_cublas-13.4.0.1-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:705d7d214fbb20f134415ecadc488abf74f444c155a6555dec5687404afb18a9" },
-    { url = "https://pypi.nvidia.com/nvidia-cublas/nvidia_cublas-13.4.0.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:53bf22e2ccbf644db74b6cc21cea7f5efb1a52aa64515438b430abbd05af4106" },
+    { url = "https://files.pythonhosted.org/packages/d0/48/8571e55aaabbd112f06a39a71fbc3abf0b8a0d450921816a13a6d5e8fa0b/nvidia_cublas-13.4.0.1-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:705d7d214fbb20f134415ecadc488abf74f444c155a6555dec5687404afb18a9", size = 513051304, upload-time = "2026-04-13T09:49:32.758Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ec/c9b2998aebe3149dee2769e501257e048c8701de51263925f4dff76ddedc/nvidia_cublas-13.4.0.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:53bf22e2ccbf644db74b6cc21cea7f5efb1a52aa64515438b430abbd05af4106", size = 404872465, upload-time = "2026-04-13T09:50:12.116Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/97/a7ac03495c1ca3c250f12f094dec46e945e38c06f24f3b11c168894a37d1/nvidia_cublas-13.4.0.1-py3-none-win_amd64.whl", hash = "sha256:37a142e2643c928f498f12f4f61c2ecd1c6c6c9608e16f6a4d45ec8d5d057733", size = 388919782, upload-time = "2026-04-13T10:09:36.942Z" },
 ]
 
 [[package]]
 name = "nvidia-cuda-cupti"
 version = "13.2.75"
-source = { registry = "https://download.pytorch.org/whl/cu132" }
+source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://pypi.nvidia.com/nvidia-cuda-cupti/nvidia_cuda_cupti-13.2.75-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:003157a0ca04d34a1f83a764dcbe36eabceda5a771e9a2cc85a461b2765888b6" },
-    { url = "https://pypi.nvidia.com/nvidia-cuda-cupti/nvidia_cuda_cupti-13.2.75-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:f75aca6bef89c625a4076a820302bb06764daa1d21595286f6bee5e237d3a187" },
+    { url = "https://files.pythonhosted.org/packages/4e/e2/b7bbe4e39781024fcc698fa3d0a788cd9559d9cba5e23fdbcff0a27783e4/nvidia_cuda_cupti-13.2.75-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:003157a0ca04d34a1f83a764dcbe36eabceda5a771e9a2cc85a461b2765888b6", size = 11759634, upload-time = "2026-04-13T09:40:35.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/2d/cbf8f6288259c502165282fdaa2b733daae98434e3f2aee2b7952ba87c6f/nvidia_cuda_cupti-13.2.75-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:f75aca6bef89c625a4076a820302bb06764daa1d21595286f6bee5e237d3a187", size = 11986992, upload-time = "2026-04-13T09:40:54.517Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/cc/05314fcb3bd2d00eeab989f1dd30e16a99361e3d0d5cb6174003c4bed9f1/nvidia_cuda_cupti-13.2.75-py3-none-win_amd64.whl", hash = "sha256:39bd75dd3ab29ad26fabd25738cc6f6cd3452d8f8f1a1ac482c395e977eaaa55", size = 8175944, upload-time = "2026-04-13T10:04:48.902Z" },
 ]
 
 [[package]]
 name = "nvidia-cuda-nvrtc"
 version = "13.2.78"
-source = { registry = "https://download.pytorch.org/whl/cu132" }
+source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://pypi.nvidia.com/nvidia-cuda-nvrtc/nvidia_cuda_nvrtc-13.2.78-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a9049031da08cbedd0c20e3470e5a978dc330af0e0326b3b05774718c665dc3e" },
-    { url = "https://pypi.nvidia.com/nvidia-cuda-nvrtc/nvidia_cuda_nvrtc-13.2.78-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a50367a7e2a0bd00fb27e5648179149cc7a60e7c7811740a5ff559f06234526d" },
+    { url = "https://files.pythonhosted.org/packages/5f/96/237b40b171e06eb65905375c4ad5c96f78c2f861ac6e8ae7f650d95e1dfd/nvidia_cuda_nvrtc-13.2.78-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a9049031da08cbedd0c20e3470e5a978dc330af0e0326b3b05774718c665dc3e", size = 47019062, upload-time = "2026-04-13T09:45:33.875Z" },
+    { url = "https://files.pythonhosted.org/packages/af/be/8476aa006686fb264d61de43e0408a8dbd001003a702574759b25e645587/nvidia_cuda_nvrtc-13.2.78-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a50367a7e2a0bd00fb27e5648179149cc7a60e7c7811740a5ff559f06234526d", size = 44754755, upload-time = "2026-04-13T09:44:58.919Z" },
+    { url = "https://files.pythonhosted.org/packages/48/35/41b84ff9b4a9acc42590be44e69f32fc867a57d7018e87c532019d627f17/nvidia_cuda_nvrtc-13.2.78-py3-none-win_amd64.whl", hash = "sha256:46aff2df5615c408f23fb968a75e5641060f89fa611a85af51a387dff9bf375b", size = 40817783, upload-time = "2026-04-13T10:06:31.711Z" },
 ]
 
 [[package]]
 name = "nvidia-cuda-runtime"
 version = "13.2.75"
-source = { registry = "https://download.pytorch.org/whl/cu132" }
+source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://pypi.nvidia.com/nvidia-cuda-runtime/nvidia_cuda_runtime-13.2.75-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36e539e8deb01568025830c1454216c26ef4b4529507220b1d8ef739bf5c6439" },
-    { url = "https://pypi.nvidia.com/nvidia-cuda-runtime/nvidia_cuda_runtime-13.2.75-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:72bf454902da594e0b833cadeddc8b7100ce1c7cf7ed9023943931be1aa913b7" },
+    { url = "https://files.pythonhosted.org/packages/f1/40/56a70b5a4e0a2881a1b7c172fea8025ab6b3cfb2de61c743fb7974d1ded4/nvidia_cuda_runtime-13.2.75-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36e539e8deb01568025830c1454216c26ef4b4529507220b1d8ef739bf5c6439", size = 2339755, upload-time = "2026-04-13T09:37:53.791Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/74/f1493b0774c6eaf0234512bb650e1ab90ce8f61fecf0b4aaf1fb416f571e/nvidia_cuda_runtime-13.2.75-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:72bf454902da594e0b833cadeddc8b7100ce1c7cf7ed9023943931be1aa913b7", size = 2321965, upload-time = "2026-04-13T09:38:26.359Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/ea/efd56431c409f292739b0f69ceae9f1469599e9e228706b4f1fad45a32ba/nvidia_cuda_runtime-13.2.75-py3-none-win_amd64.whl", hash = "sha256:16a2ff1b786d52c7b4d4439c7f5fc05cf9e086071f51efd5163989dee65bd4ea", size = 3154350, upload-time = "2026-04-13T10:04:17.355Z" },
 ]
 
 [[package]]
 name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
-source = { registry = "https://download.pytorch.org/whl/cu132" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas", marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 wheels = [
-    { url = "https://pypi.nvidia.com/nvidia-cudnn-cu13/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1" },
-    { url = "https://pypi.nvidia.com/nvidia-cudnn-cu13/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0c45dd8eeb50b603f07995b1b300c62ffe6a1980482b82b3bcf94a4ca9d49304" },
+    { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/edb9c0ae051602c3ccaffe424256463636d639e27d7f302dde9975ef9e7a/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0c45dd8eeb50b603f07995b1b300c62ffe6a1980482b82b3bcf94a4ca9d49304", size = 366173588, upload-time = "2026-03-09T19:29:34.474Z" },
+    { url = "https://files.pythonhosted.org/packages/78/39/21507455b1bca8b5702a9e9fc6ce73735f216f558dac2c9ede58e4d456b8/nvidia_cudnn_cu13-9.20.0.48-py3-none-win_amd64.whl", hash = "sha256:af8139732b99c0118be65ea5aac97f0d46018f8c552889e49d2fb0c6261a4a24", size = 350712614, upload-time = "2026-03-09T19:31:11.398Z" },
 ]
 
 [[package]]
 name = "nvidia-cufft"
 version = "12.2.0.46"
-source = { registry = "https://download.pytorch.org/whl/cu132" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 wheels = [
-    { url = "https://pypi.nvidia.com/nvidia-cufft/nvidia_cufft-12.2.0.46-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2e8f3a22c2745f95327b7639ba2868ea2cbd5d3131ebe6313394e24164054f41" },
-    { url = "https://pypi.nvidia.com/nvidia-cufft/nvidia_cufft-12.2.0.46-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a9667ae4d81b9e54ddbbad24a9e72334f89d4fc184566d05ef028e2760c820eb" },
+    { url = "https://files.pythonhosted.org/packages/be/b1/6e36381739b51e692d91646298ad5685c562929b899331c2bb6e9722a176/nvidia_cufft-12.2.0.46-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2e8f3a22c2745f95327b7639ba2868ea2cbd5d3131ebe6313394e24164054f41", size = 218244743, upload-time = "2026-04-13T09:51:24.75Z" },
+    { url = "https://files.pythonhosted.org/packages/36/3e/8d717a6e1f6e27b85b64650b1104dbcf6108c9dc7e27e9e26a0d8e936cc5/nvidia_cufft-12.2.0.46-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a9667ae4d81b9e54ddbbad24a9e72334f89d4fc184566d05ef028e2760c820eb", size = 218258098, upload-time = "2026-04-13T09:52:04.915Z" },
+    { url = "https://files.pythonhosted.org/packages/03/34/8bed3c530c0c732de39281ca51fe4ba83503cfc055b7935e8377f7cbb9f8/nvidia_cufft-12.2.0.46-py3-none-win_amd64.whl", hash = "sha256:e35b0cb44a971dad5cbbf8d166fb89061f329b41e466631ee85d301628f1b943", size = 217463595, upload-time = "2026-04-13T10:10:12.17Z" },
 ]
 
 [[package]]
 name = "nvidia-cufile"
 version = "1.17.1.22"
-source = { registry = "https://download.pytorch.org/whl/cu132" }
+source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://pypi.nvidia.com/nvidia-cufile/nvidia_cufile-1.17.1.22-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:bec33d7f1f12691dce330275246587569c2ed90b1ce43b0f94b3e1ce9268744b" },
-    { url = "https://pypi.nvidia.com/nvidia-cufile/nvidia_cufile-1.17.1.22-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:87feaf8c3ad20d3d03a01933181801ff6892bace5c8f0b1e4b48f319d3e62d36" },
+    { url = "https://files.pythonhosted.org/packages/fe/fd/4b4157512a131a51e1514d40d0199b1c5b7b10c6856db274ff22e5fe15be/nvidia_cufile-1.17.1.22-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:bec33d7f1f12691dce330275246587569c2ed90b1ce43b0f94b3e1ce9268744b", size = 1226736, upload-time = "2026-04-13T09:52:40.142Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c5/661a73a9042fc5f81cdd5fe6e89f4170b3b33f7962e709987e2b5e5f1381/nvidia_cufile-1.17.1.22-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:87feaf8c3ad20d3d03a01933181801ff6892bace5c8f0b1e4b48f319d3e62d36", size = 1387670, upload-time = "2026-04-13T09:52:57.783Z" },
 ]
 
 [[package]]
 name = "nvidia-curand"
 version = "10.4.2.55"
-source = { registry = "https://download.pytorch.org/whl/cu132" }
+source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://pypi.nvidia.com/nvidia-curand/nvidia_curand-10.4.2.55-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:342e40ddcaedc92aedc72839e0c10064096fceea2f1d0eb57951f86d2901f8c0" },
-    { url = "https://pypi.nvidia.com/nvidia-curand/nvidia_curand-10.4.2.55-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b4080cab49d4939f8e46b2c195c76c698d2289835c36ede558836daa40000e70" },
+    { url = "https://files.pythonhosted.org/packages/ee/7c/7c2042b5badc251236bc1f23627d5554cf2ecff37e92ea0a9d39dfc20a61/nvidia_curand-10.4.2.55-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:342e40ddcaedc92aedc72839e0c10064096fceea2f1d0eb57951f86d2901f8c0", size = 62372157, upload-time = "2026-04-13T09:53:32.34Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/bc/f02a1d180d288e49b1a4548698b59755e9c485ee39c041fdeaf4d2cc2117/nvidia_curand-10.4.2.55-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b4080cab49d4939f8e46b2c195c76c698d2289835c36ede558836daa40000e70", size = 59920450, upload-time = "2026-04-13T09:54:07.224Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/72/9301996f4d54bd770001e05fa182be1ef5c81deccd98980b296d3b2fb659/nvidia_curand-10.4.2.55-py3-none-win_amd64.whl", hash = "sha256:ce09678a852f4c224738abc56ea196bf981bb0db25b720438bd8416c5d52f056", size = 55508324, upload-time = "2026-04-13T10:10:46.673Z" },
 ]
 
 [[package]]
 name = "nvidia-cusolver"
 version = "12.2.0.1"
-source = { registry = "https://download.pytorch.org/whl/cu132" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
-    { name = "nvidia-cusparse", marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 wheels = [
-    { url = "https://pypi.nvidia.com/nvidia-cusolver/nvidia_cusolver-12.2.0.1-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c9def09fcf300b9465cdf800142abf10149df28c4290bdf9e7b4a700480d31d7" },
-    { url = "https://pypi.nvidia.com/nvidia-cusolver/nvidia_cusolver-12.2.0.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4693ea3c2a5d20369da7b5a4970a41df9b40f1b6f2ef9909c95f7c8c8c5ffb4d" },
+    { url = "https://files.pythonhosted.org/packages/94/21/21e5c491a8285a6ed039cbb8c60ec13ff3aff60c669e1caa4adaeb71f997/nvidia_cusolver-12.2.0.1-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c9def09fcf300b9465cdf800142abf10149df28c4290bdf9e7b4a700480d31d7", size = 249744985, upload-time = "2026-04-13T09:54:33.757Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/97/a3c41eac54c89f6aac788d2b3ccd6642b32aa6b79650af3dedb8ee7c2bfa/nvidia_cusolver-12.2.0.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4693ea3c2a5d20369da7b5a4970a41df9b40f1b6f2ef9909c95f7c8c8c5ffb4d", size = 227391570, upload-time = "2026-04-13T09:55:12.999Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/60/4d8cd064a29e53f6df1e1f22791d46457063191fbe4267caf1f5d58f70d6/nvidia_cusolver-12.2.0.1-py3-none-win_amd64.whl", hash = "sha256:0776a83624e39a277cb26cc064164a70b7e89a594fb950bf0771be20c8eb8172", size = 217210178, upload-time = "2026-04-13T10:11:25.025Z" },
 ]
 
 [[package]]
 name = "nvidia-cusparse"
 version = "12.7.10.1"
-source = { registry = "https://download.pytorch.org/whl/cu132" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 wheels = [
-    { url = "https://pypi.nvidia.com/nvidia-cusparse/nvidia_cusparse-12.7.10.1-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80cc98b38fdcf054a80bd9782fe2e63c66f90e202cac269f641357ccac5fe7e3" },
-    { url = "https://pypi.nvidia.com/nvidia-cusparse/nvidia_cusparse-12.7.10.1-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f0d110640aa63e7182fa787cc245afa07c5fb84ac30f1c4029e4fa3012353172" },
+    { url = "https://files.pythonhosted.org/packages/b5/09/9f1fa88dd305e838b71f2ca4e50064e7cbdf2e15cd6410d9e1b74066cc41/nvidia_cusparse-12.7.10.1-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80cc98b38fdcf054a80bd9782fe2e63c66f90e202cac269f641357ccac5fe7e3", size = 168860233, upload-time = "2026-04-13T09:55:48.891Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bd/bad43b37bcf13167637bef26399693d517b95092d742e8749eda5f4a85f3/nvidia_cusparse-12.7.10.1-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f0d110640aa63e7182fa787cc245afa07c5fb84ac30f1c4029e4fa3012353172", size = 150855566, upload-time = "2026-04-13T09:56:29.21Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ca/7b910f56e02a251df7ed59f8f5f628da7ffd2422bc3e43c292980b1578ec/nvidia_cusparse-12.7.10.1-py3-none-win_amd64.whl", hash = "sha256:8786474c768d147e9969d3fac96b46399eb5f397c57a2ad57c1d4cdc4bb59f65", size = 149165663, upload-time = "2026-04-13T10:12:04.286Z" },
 ]
 
 [[package]]
 name = "nvidia-cusparselt-cu13"
 version = "0.8.1"
-source = { registry = "https://download.pytorch.org/whl/cu132" }
+source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://pypi.nvidia.com/nvidia-cusparselt-cu13/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4dca476c50bf4780d46cd0bfbd82e2bc10a08e4fef7950917ce8d7578d22a23f" },
-    { url = "https://pypi.nvidia.com/nvidia-cusparselt-cu13/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:786ce87568c303fadb5afcc7102d454cd3040d75f6f8626f5db460d1871f4dd0" },
+    { url = "https://files.pythonhosted.org/packages/46/e1/cdc1797eadf82d3a9a575a19b33fdc871a97edbec42c00b5b5e914f4aff4/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4dca476c50bf4780d46cd0bfbd82e2bc10a08e4fef7950917ce8d7578d22a23f", size = 221051344, upload-time = "2025-09-05T18:49:51.289Z" },
+    { url = "https://files.pythonhosted.org/packages/34/7d/2661f2fb3ac4302f3a246f5fc030213ac60c1fe0bce84f9783dbd831dbb7/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:786ce87568c303fadb5afcc7102d454cd3040d75f6f8626f5db460d1871f4dd0", size = 170148586, upload-time = "2025-09-05T18:50:50.248Z" },
+    { url = "https://files.pythonhosted.org/packages/31/83/f3647ce26916c94a6ca4ff1810623e2c405cff2dea6e78d29516b2514df9/nvidia_cusparselt_cu13-0.8.1-py3-none-win_amd64.whl", hash = "sha256:dccbd362f91a7b9024d1f55ee9f548ac065027ff15d8c8b0db889ab3a8f31215", size = 156885108, upload-time = "2025-09-05T18:51:35.958Z" },
 ]
 
 [[package]]
 name = "nvidia-nccl-cu13"
 version = "2.29.7"
-source = { registry = "https://download.pytorch.org/whl/cu132" }
+source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://pypi.nvidia.com/nvidia-nccl-cu13/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:674a12383e3c38a1bcccae7d4f3633b37852230b6047883cb2f4c2d1b36d9bf5" },
-    { url = "https://pypi.nvidia.com/nvidia-nccl-cu13/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:edd81538446786ec3b73972543e53bb43bcaf0bfc8ef76cb679fcc390ffe136d" },
+    { url = "https://files.pythonhosted.org/packages/72/0d/daf50d44177ee0cbc7ff0a0c91eb5ff676c82be42f9a970bc7597f440c3a/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:674a12383e3c38a1bcccae7d4f3633b37852230b6047883cb2f4c2d1b36d9bf5", size = 206014712, upload-time = "2026-03-03T05:34:20.843Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f4/58e4e91b6919367c7aafb8e36fce9aad1a3047e536bf7e2fd560927d3a4c/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:edd81538446786ec3b73972543e53bb43bcaf0bfc8ef76cb679fcc390ffe136d", size = 205976000, upload-time = "2026-03-03T05:36:24.472Z" },
 ]
 
 [[package]]
 name = "nvidia-nvjitlink"
 version = "13.2.78"
-source = { registry = "https://download.pytorch.org/whl/cu132" }
+source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://pypi.nvidia.com/nvidia-nvjitlink/nvidia_nvjitlink-13.2.78-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:27964b6702aeceee05fc0ab47b4c97e3f8966bd47d05d9827e913c49a025656b" },
-    { url = "https://pypi.nvidia.com/nvidia-nvjitlink/nvidia_nvjitlink-13.2.78-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f8db47f159e434f5c7b9de53c4bc71cfa03ac3aeae717db5dc91b846c506b0a3" },
+    { url = "https://files.pythonhosted.org/packages/1e/b5/dae67f0c45516cfaff2d7fba873c7425c2866d4c9ede5c14a269d89ed79b/nvidia_nvjitlink-13.2.78-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:27964b6702aeceee05fc0ab47b4c97e3f8966bd47d05d9827e913c49a025656b", size = 41370766, upload-time = "2026-04-13T09:59:28.799Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ab/ff01689cfeac7c197605a59c90f48815fbf21d8b4c008e6562cb927ffdc1/nvidia_nvjitlink-13.2.78-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f8db47f159e434f5c7b9de53c4bc71cfa03ac3aeae717db5dc91b846c506b0a3", size = 39285235, upload-time = "2026-04-13T09:59:06.412Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/b9/82c46bbf226d6982608937187386ed3f783369ece4696ecf426b12ae891a/nvidia_nvjitlink-13.2.78-py3-none-win_amd64.whl", hash = "sha256:fc64c0708d301705bc3df36b16ff226e07f78b571e868a7489dac78282048a25", size = 36791926, upload-time = "2026-04-13T10:13:40.945Z" },
 ]
 
 [[package]]
 name = "nvidia-nvshmem-cu13"
 version = "3.4.5"
-source = { registry = "https://download.pytorch.org/whl/cu132" }
+source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://pypi.nvidia.com/nvidia-nvshmem-cu13/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dc2a197f38e5d0376ad52cd1a2a3617d3cdc150fd5966f4aee9bcebb1d68fe9" },
-    { url = "https://pypi.nvidia.com/nvidia-nvshmem-cu13/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:290f0a2ee94c9f3687a02502f3b9299a9f9fe826e6d0287ee18482e78d495b80" },
+    { url = "https://files.pythonhosted.org/packages/dc/0f/05cc9c720236dcd2db9c1ab97fff629e96821be2e63103569da0c9b72f19/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dc2a197f38e5d0376ad52cd1a2a3617d3cdc150fd5966f4aee9bcebb1d68fe9", size = 60215947, upload-time = "2025-09-06T00:32:20.022Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/35/a9bf80a609e74e3b000fef598933235c908fcefcef9026042b8e6dfde2a9/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:290f0a2ee94c9f3687a02502f3b9299a9f9fe826e6d0287ee18482e78d495b80", size = 60412546, upload-time = "2025-09-06T00:32:41.564Z" },
 ]
 
 [[package]]
 name = "nvidia-nvtx"
 version = "13.2.75"
-source = { registry = "https://download.pytorch.org/whl/cu132" }
+source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://pypi.nvidia.com/nvidia-nvtx/nvidia_nvtx-13.2.75-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2d7c24fc582d841493c6dc2cf017c25e4428cf583a3bd9e9325a65f0ecc65f73" },
-    { url = "https://pypi.nvidia.com/nvidia-nvtx/nvidia_nvtx-13.2.75-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d8e1c4a14a21d6dd4bc2fc59eb1e3f42447db40edf5d0f580c0eba5f9abb606c" },
+    { url = "https://files.pythonhosted.org/packages/b0/cc/314eac684677dced22b913b5d1b3d03adcbe59d6c7332c5d04f864cdb079/nvidia_nvtx-13.2.75-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2d7c24fc582d841493c6dc2cf017c25e4428cf583a3bd9e9325a65f0ecc65f73", size = 153460, upload-time = "2026-04-13T09:46:23.256Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/48/c02f2aa1662edaddac87e0501142a65765af8010a788b087d920a9f80fb7/nvidia_nvtx-13.2.75-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d8e1c4a14a21d6dd4bc2fc59eb1e3f42447db40edf5d0f580c0eba5f9abb606c", size = 154291, upload-time = "2026-04-13T09:45:53.009Z" },
+    { url = "https://files.pythonhosted.org/packages/30/38/6aad46328210858348cb8b90729a223037cb0cd6681657e92d95d016d536/nvidia_nvtx-13.2.75-py3-none-win_amd64.whl", hash = "sha256:b0a85fe36c3e9d56225fc30297577535a5a35f19545c8073926fe89807617e52", size = 142534, upload-time = "2026-04-13T10:07:03.941Z" },
 ]
 
 [[package]]
@@ -1891,13 +2041,13 @@ name = "onnxruntime-gpu"
 version = "1.26.0"
 source = { url = "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-cuda-13/pypi/download/onnxruntime-gpu/1.26.0/onnxruntime_gpu-1.26.0-cp313-cp313-manylinux_2_34_aarch64.whl" }
 resolution-markers = [
-    "(platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "platform_machine == 'aarch64' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "flatbuffers", marker = "(platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')" },
-    { name = "numpy", marker = "(platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')" },
-    { name = "packaging", marker = "(platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')" },
-    { name = "protobuf", marker = "(platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')" },
+    { name = "flatbuffers", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "packaging", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "protobuf", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 wheels = [
     { url = "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-cuda-13/pypi/download/onnxruntime-gpu/1.26.0/onnxruntime_gpu-1.26.0-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:a254b3f40f55ecd36dd0bf0d8a035261d84172b3f52d70de0bfc80f3836b4968" },
@@ -1924,14 +2074,14 @@ name = "onnxruntime-gpu"
 version = "1.27.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "sys_platform == 'win32'",
     "platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "flatbuffers", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
-    { name = "numpy", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
-    { name = "packaging", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
-    { name = "protobuf", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
+    { name = "flatbuffers", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or sys_platform == 'win32' or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or sys_platform == 'win32' or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "packaging", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or sys_platform == 'win32' or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "protobuf", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or sys_platform == 'win32' or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8f/8d/6509743801131f1d3791f638ae31edef7701e93c7a4523d74115247dd7d1/onnxruntime_gpu-1.27.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7e6eb554d35706ee154b583dd32e4167a93aa55d3670f59754f43860fd649b92", size = 220304092, upload-time = "2026-06-18T18:27:31.18Z" },
@@ -1955,7 +2105,8 @@ name = "opencv-python"
 version = "4.11.0.86"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/17/06/68c27a523103dad5837dc5b87e71285280c4f098c60e4fe8a8db6486ab09/opencv-python-4.11.0.86.tar.gz", hash = "sha256:03d60ccae62304860d232272e4a4fda93c39d595780cb40b161b310244b736a4", size = 95171956, upload-time = "2025-01-16T13:52:24.737Z" }
 wheels = [
@@ -1972,7 +2123,8 @@ name = "opencv-python-headless"
 version = "4.11.0.86"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/36/2f/5b2b3ba52c864848885ba988f24b7f105052f68da9ab0e693cc7c25b0b30/opencv-python-headless-4.11.0.86.tar.gz", hash = "sha256:996eb282ca4b43ec6a3972414de0e2331f5d9cda2b41091a49739c19fb843798", size = 95177929, upload-time = "2025-01-16T13:53:40.22Z" }
 wheels = [
@@ -2034,9 +2186,10 @@ name = "pandas"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "python-dateutil" },
-    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
 wheels = [
@@ -2069,34 +2222,43 @@ wheels = [
 [[package]]
 name = "pillow"
 version = "12.2.0"
-source = { registry = "https://download.pytorch.org/whl/cu132" }
-sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5" }
+source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }
+resolution-markers = [
+    "platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "sys_platform == 'darwin'",
+    "sys_platform == 'win32'",
+]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/01/53d10cf0dbad820a8db274d259a37ba50b88b24768ddccec07355382d5ad/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:8297651f5b5679c19968abefd6bb84d95fe30ef712eb1b2d9b2d31ca61267f4c" },
-    { url = "https://files.pythonhosted.org/packages/0f/98/f3a6657ecb698c937f6c76ee564882945f29b79bad496abcba0e84659ec5/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:50d8520da2a6ce0af445fa6d648c4273c3eeefbc32d7ce049f22e8b5c3daecc2" },
-    { url = "https://files.pythonhosted.org/packages/69/bc/8986948f05e3ea490b8442ea1c1d4d990b24a7e43d8a51b2c7d8b1dced36/pillow-12.2.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:766cef22385fa1091258ad7e6216792b156dc16d8d3fa607e7545b2b72061f1c" },
-    { url = "https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795" },
-    { url = "https://files.pythonhosted.org/packages/71/43/905a14a8b17fdb1ccb58d282454490662d2cb89a6bfec26af6d3520da5ec/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f" },
-    { url = "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed" },
-    { url = "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9" },
-    { url = "https://files.pythonhosted.org/packages/4b/6e/3ccb54ce8ec4ddd1accd2d89004308b7b0b21c4ac3d20fa70af4760a4330/pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed" },
-    { url = "https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3" },
-    { url = "https://files.pythonhosted.org/packages/78/5f/e9f86ab0146464e8c133fe85df987ed9e77e08b29d8d35f9f9f4d6f917ba/pillow-12.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00a2865911330191c0b818c59103b58a5e697cae67042366970a6b6f1b20b7f9" },
-    { url = "https://files.pythonhosted.org/packages/ed/1e/409007f56a2fdce61584fd3acbc2bbc259857d555196cedcadc68c015c82/pillow-12.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e1757442ed87f4912397c6d35a0db6a7b52592156014706f17658ff58bbf795" },
-    { url = "https://files.pythonhosted.org/packages/23/c4/7349421080b12fb35414607b8871e9534546c128a11965fd4a7002ccfbee/pillow-12.2.0-cp313-cp313-win32.whl", hash = "sha256:144748b3af2d1b358d41286056d0003f47cb339b8c43a9ea42f5fea4d8c66b6e" },
-    { url = "https://files.pythonhosted.org/packages/3f/82/8a3739a5e470b3c6cbb1d21d315800d8e16bff503d1f16b03a4ec3212786/pillow-12.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:390ede346628ccc626e5730107cde16c42d3836b89662a115a921f28440e6a3b" },
-    { url = "https://files.pythonhosted.org/packages/c3/25/f968f618a062574294592f668218f8af564830ccebdd1fa6200f598e65c5/pillow-12.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:8023abc91fba39036dbce14a7d6535632f99c0b857807cbbbf21ecc9f4717f06" },
-    { url = "https://files.pythonhosted.org/packages/4d/a4/b342930964e3cb4dce5038ae34b0eab4653334995336cd486c5a8c25a00c/pillow-12.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:042db20a421b9bafecc4b84a8b6e444686bd9d836c7fd24542db3e7df7baad9b" },
-    { url = "https://files.pythonhosted.org/packages/9f/de/23198e0a65a9cf06123f5435a5d95cea62a635697f8f03d134d3f3a96151/pillow-12.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd025009355c926a84a612fecf58bb315a3f6814b17ead51a8e48d3823d9087f" },
-    { url = "https://files.pythonhosted.org/packages/01/a6/1265e977f17d93ea37aa28aa81bad4fa597933879fac2520d24e021c8da3/pillow-12.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88ddbc66737e277852913bd1e07c150cc7bb124539f94c4e2df5344494e0a612" },
-    { url = "https://files.pythonhosted.org/packages/3c/83/5982eb4a285967baa70340320be9f88e57665a387e3a53a7f0db8231a0cd/pillow-12.2.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d362d1878f00c142b7e1a16e6e5e780f02be8195123f164edf7eddd911eefe7c" },
-    { url = "https://files.pythonhosted.org/packages/4e/48/6ffc514adce69f6050d0753b1a18fd920fce8cac87620d5a31231b04bfc5/pillow-12.2.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c727a6d53cb0018aadd8018c2b938376af27914a68a492f59dfcaca650d5eea" },
-    { url = "https://files.pythonhosted.org/packages/36/a3/f9a77144231fb8d40ee27107b4463e205fa4677e2ca2548e14da5cf18dce/pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd8c21c98c5cc60653bcb311bef2ce0401642b7ce9d09e03a7da87c878289d4" },
-    { url = "https://files.pythonhosted.org/packages/c1/fc/ac4ee3041e7d5a565e1c4fd72a113f03b6394cc72ab7089d27608f8aaccb/pillow-12.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f08483a632889536b8139663db60f6724bfcb443c96f1b18855860d7d5c0fd4" },
-    { url = "https://files.pythonhosted.org/packages/c0/a8/27fb307055087f3668f6d0a8ccb636e7431d56ed0750e07a60547b1e083e/pillow-12.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dac8d77255a37e81a2efcbd1fc05f1c15ee82200e6c240d7e127e25e365c39ea" },
-    { url = "https://files.pythonhosted.org/packages/ad/4b/926ab182c07fccae9fcb120043464e1ff1564775ec8864f21a0ebce6ac25/pillow-12.2.0-cp313-cp313t-win32.whl", hash = "sha256:ee3120ae9dff32f121610bb08e4313be87e03efeadfc6c0d18f89127e24d0c24" },
-    { url = "https://files.pythonhosted.org/packages/c2/c4/f9e476451a098181b30050cc4c9a3556b64c02cf6497ea421ac047e89e4b/pillow-12.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:325ca0528c6788d2a6c3d40e3568639398137346c3d6e66bb61db96b96511c98" },
-    { url = "https://files.pythonhosted.org/packages/00/a4/285f12aeacbe2d6dc36c407dfbbe9e96d4a80b0fb710a337f6d2ad978c75/pillow-12.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e5a76d03a6c6dcef67edabda7a52494afa4035021a79c8558e14af25313d453" },
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl" },
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/pillow-12.2.0-cp313-cp313-win_amd64.whl" },
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/pillow-12.2.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl" },
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/pillow-12.2.0-cp313-cp313t-win_amd64.whl" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "platform_machine == 'aarch64' and sys_platform == 'linux'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/3d/bb7fca845737cf9d7dbde16ed1843984665ff2e0a518f5db43e77ec540b9/pillow-12.3.0.tar.gz", hash = "sha256:3b8182a766685eaa002637e28b4ec8d6b18819a0c71f579bf0dbaa5830297cce", size = 47025035, upload-time = "2026-07-01T11:56:38.965Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/ac/31fb64e1e7efb5a4b50cd3d92049ba89ac6e4d8d3bb6a74e15048ca3353e/pillow-12.3.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:21900ce7ba264168cd50defae43cd75d25c833ad4ad6e73ffc5596d12e25ac89", size = 4161684, upload-time = "2026-07-01T11:54:25.934Z" },
+    { url = "https://files.pythonhosted.org/packages/87/b4/9805e23d2b4d77842b468513841fda254ee42f0289d25088340e4ff46e2d/pillow-12.3.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:4e8c2a84d977f50b9daed6eeaf3baef67d00d5d74d932288f02cb94518ee3ace", size = 4255487, upload-time = "2026-07-01T11:54:27.935Z" },
+    { url = "https://files.pythonhosted.org/packages/df/39/ecf519435a200c693fe053a6ee4d835b41cf963a4dfc2551c4e637cb2a71/pillow-12.3.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:ae26d61dfa7a47befdc7572b521024e8745f3d809bd95ca9505a7bba9ef849ec", size = 3696433, upload-time = "2026-07-01T11:54:29.813Z" },
+    { url = "https://files.pythonhosted.org/packages/42/92/2fc3ffad878ae8dd5469ec1bc8eb83b71f48e13efdf68f02709003982a32/pillow-12.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7a743ff716f746fc19a9557f60dab1600d4613255f8a7aeb3cdde4db7eb15a66", size = 5345889, upload-time = "2026-07-01T11:54:31.97Z" },
+    { url = "https://files.pythonhosted.org/packages/10/76/8803c13605b763d33d156c4678fc77f8443389c0c51c8aef707bb02015f4/pillow-12.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d69141514cc30b774ceea5e3ed3a6635c8d8a96edf664689b890f4089111fb35", size = 4780109, upload-time = "2026-07-01T11:54:34.026Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/01/e18aff37cb0b4aac47ac90f016d347a49aca667ef97f190b06ac2aabc928/pillow-12.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f7401aebd7f581d7f83a439d87d474999317ee099218e5ad25d125290990ba65", size = 6263736, upload-time = "2026-07-01T11:54:36.131Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/62/de5bdd77d935331f4f802edc11e4d82950f642caad6cb2f949837b8560e2/pillow-12.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0847a763afefb695bc912d7c131e7e0632d4edc1d8698f58ddabec8e46b8b6d3", size = 6937129, upload-time = "2026-07-01T11:54:38.216Z" },
+    { url = "https://files.pythonhosted.org/packages/70/4d/105627a13300c5e0df1d174230b32fd1273062c96f7745fd552b945d1e1d/pillow-12.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:571b9fcb07b97ef3a492028fb3d2dc0993ca23a06138b0315286566d29ef718a", size = 6339562, upload-time = "2026-07-01T11:54:40.354Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/1d/f13de01a553988ab895ba1c722e06cf3144d4f57656fd5b81b6d881f1179/pillow-12.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:756c768d0c9c2955feb7a56c37ea24aea2e369f8d36a88da270b6a9f19e62b5e", size = 7049439, upload-time = "2026-07-01T11:54:42.489Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/f9/066794cca041b969964f779ee5fa66a9498bbf34248ac39c5d7954e4198f/pillow-12.3.0-cp313-cp313-win32.whl", hash = "sha256:a876864214e136f0eb367788dbd7df045f4806801518e2cfe9e13229cfe06d8f", size = 6473287, upload-time = "2026-07-01T11:54:44.9Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/9b/7a58e61d62be561da3a356fe2384d4059a6345fc130e23ef1c36a5b81d24/pillow-12.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:1cca606cd25738df4ed873d5ad46bbdb3d83b5cbca291f6b4ff13a4df6b0bbe8", size = 7239691, upload-time = "2026-07-01T11:54:47.141Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b0/c4ed4f0ef8f8fa5ee8351537db6650bb8189f7e118842978dd6589065692/pillow-12.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:b629de27fda84b42cde7edef0d85f13b958b47f6e9bbcbba9b673c562a89bd8b", size = 2568185, upload-time = "2026-07-01T11:54:49.137Z" },
 ]
 
 [[package]]
@@ -2122,7 +2284,7 @@ name = "portalocker"
 version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "pywin32", marker = "sys_platform == 'win32' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/77/65b857a69ed876e1951e88aaba60f5ce6120c33703f7cb61a3c894b8c1b6/portalocker-3.2.0.tar.gz", hash = "sha256:1f3002956a54a8c3730586c5c77bf18fae4149e07eaf1c29fc3faf4d5a3f89ac", size = 95644, upload-time = "2025-06-14T13:20:40.03Z" }
 wheels = [
@@ -2149,7 +2311,8 @@ name = "pot"
 version = "0.9.6.post1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "scipy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/8b/5f939eaf1fbeb7ff914fe540d659486951a056e5537b8f454362045b6c72/pot-0.9.6.post1.tar.gz", hash = "sha256:9b6cc14a8daecfe1268268168cf46548f9130976b22b24a9e8ec62a734be6c43", size = 604243, upload-time = "2025-09-22T12:51:14.894Z" }
@@ -2303,7 +2466,8 @@ name = "pycocotools"
 version = "2.0.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a2/df/32354b5dda963ffdfc8f75c9acf8828ef7890723a4ed57bb3ff2dc1d6f7e/pycocotools-2.0.11.tar.gz", hash = "sha256:34254d76da85576fcaf5c1f3aa9aae16b8cb15418334ba4283b800796bd1993d", size = 25381, upload-time = "2025-12-15T22:31:46.148Z" }
 wheels = [
@@ -2393,17 +2557,19 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "accelerate" },
     { name = "addict" },
-    { name = "bitsandbytes", marker = "sys_platform != 'darwin'" },
+    { name = "bitsandbytes", marker = "sys_platform != 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "datasets" },
     { name = "einops" },
     { name = "facexlib" },
     { name = "future" },
     { name = "lmdb" },
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "openai-clip" },
     { name = "opencv-python-headless" },
     { name = "pandas" },
-    { name = "pillow" },
+    { name = "pillow", version = "12.2.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "pillow", version = "12.3.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pyyaml" },
@@ -2414,10 +2580,12 @@ dependencies = [
     { name = "sentencepiece" },
     { name = "tensorboard" },
     { name = "timm" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "sys_platform != 'darwin'" },
-    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "torchvision", version = "0.27.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "sys_platform != 'darwin'" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0+rocm7.14.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torchvision", version = "0.27.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torchvision", version = "0.27.0+rocm7.14.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "tqdm" },
     { name = "transformers" },
     { name = "yapf" },
@@ -2489,7 +2657,7 @@ name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
@@ -2576,9 +2744,11 @@ name = "pytorch-optimizer"
 version = "3.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "sys_platform != 'darwin'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0+rocm7.14.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/89/fc/313e6ad458114f3b5ad982c72343f88ef686a238787bcc39cad866a39282/pytorch_optimizer-3.10.0.tar.gz", hash = "sha256:da50f3700e403ac0ce774cbbfdfe94a3f39162eca65eea79d67cfde28ead642b", size = 21314846, upload-time = "2026-03-01T06:20:11.622Z" }
 wheels = [
@@ -2694,6 +2864,70 @@ wheels = [
 ]
 
 [[package]]
+name = "rocm"
+version = "7.14.0"
+source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }
+dependencies = [
+    { name = "rocm-sdk-core", marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+]
+sdist = { url = "https://repo.amd.com/rocm/whl-multi-arch/rocm-7.14.0.tar.gz" }
+
+[package.optional-dependencies]
+libraries = [
+    { name = "rocm-sdk-libraries", marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+]
+
+[[package]]
+name = "rocm-bootstrap"
+version = "0.1.0"
+source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }
+wheels = [
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/rocm_bootstrap-0.1.0-py3-none-any.whl" },
+]
+
+[[package]]
+name = "rocm-sdk-core"
+version = "7.14.0"
+source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }
+wheels = [
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/rocm_sdk_core-7.14.0-py3-none-linux_x86_64.whl" },
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/rocm_sdk_core-7.14.0-py3-none-win_amd64.whl" },
+]
+
+[[package]]
+name = "rocm-sdk-device-gfx1200"
+version = "7.14.0"
+source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }
+dependencies = [
+    { name = "rocm-sdk-libraries", marker = "sys_platform == 'win32'" },
+]
+wheels = [
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/rocm_sdk_device_gfx1200-7.14.0-py3-none-linux_x86_64.whl" },
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/rocm_sdk_device_gfx1200-7.14.0-py3-none-win_amd64.whl" },
+]
+
+[[package]]
+name = "rocm-sdk-device-gfx1201"
+version = "7.14.0"
+source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }
+dependencies = [
+    { name = "rocm-sdk-libraries", marker = "sys_platform == 'win32'" },
+]
+wheels = [
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/rocm_sdk_device_gfx1201-7.14.0-py3-none-linux_x86_64.whl" },
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/rocm_sdk_device_gfx1201-7.14.0-py3-none-win_amd64.whl" },
+]
+
+[[package]]
+name = "rocm-sdk-libraries"
+version = "7.14.0"
+source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }
+wheels = [
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/rocm_sdk_libraries-7.14.0-py3-none-linux_x86_64.whl" },
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/rocm_sdk_libraries-7.14.0-py3-none-win_amd64.whl" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.9"
 source = { registry = "https://pypi.org/simple" }
@@ -2750,7 +2984,8 @@ dependencies = [
     { name = "ftfy" },
     { name = "huggingface-hub" },
     { name = "iopath" },
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "regex" },
     { name = "timm" },
     { name = "tqdm" },
@@ -2765,9 +3000,11 @@ dependencies = [
     { name = "imageio" },
     { name = "lazy-loader" },
     { name = "networkx" },
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "packaging" },
-    { name = "pillow" },
+    { name = "pillow", version = "12.2.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "pillow", version = "12.3.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "scipy" },
     { name = "tifffile" },
 ]
@@ -2798,7 +3035,8 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "joblib" },
     { name = "narwhals" },
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "scipy" },
     { name = "threadpoolctl" },
 ]
@@ -2817,7 +3055,8 @@ name = "scipy"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -2849,14 +3088,18 @@ version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
-    { name = "numpy" },
-    { name = "pillow" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "pillow", version = "12.2.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "pillow", version = "12.3.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "safetensors" },
     { name = "timm" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "sys_platform != 'darwin'" },
-    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "torchvision", version = "0.27.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "sys_platform != 'darwin'" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0+rocm7.14.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torchvision", version = "0.27.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torchvision", version = "0.27.0+rocm7.14.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "tqdm" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/15/fa/d5a29d49240fb10bdead608b4d0c6805684a8f63b1f65863502be65b1ca4/segmentation_models_pytorch-0.5.0.tar.gz", hash = "sha256:cabba8aced6ef7bdcd6288dd9e1dc2840848aa819d539c455bd07aeceb2fdf96", size = 105150, upload-time = "2025-04-17T10:43:45.755Z" }
@@ -2909,10 +3152,9 @@ wheels = [
 [[package]]
 name = "setuptools"
 version = "81.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/1c/73e719955c59b8e424d015ab450f51c0af856ae46ea2da83eba51cc88de1/setuptools-81.0.0.tar.gz", hash = "sha256:487b53915f52501f0a79ccfd0c02c165ffe06631443a886740b91af4b7a5845a", size = 1198299, upload-time = "2026-02-06T21:10:39.601Z" }
+source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl", hash = "sha256:fdd925d5c5d9f62e4b74b30d6dd7828ce236fd6ed998a08d81de62ce5a6310d6", size = 1062021, upload-time = "2026-02-06T21:10:37.175Z" },
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/setuptools-81.0.0-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -2999,10 +3241,12 @@ version = "0.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numba" },
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "pot" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "sys_platform != 'darwin'" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0+rocm7.14.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "torchopt" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/00/0b/f595833ec32c4a79c0d9d43440080c9637e442b4f3725e9b242415756f32/softtorch-0.1.1.tar.gz", hash = "sha256:b56ca69695739617ca50cc6cdce4584c33207fa19c58b200b49a9869cd44e531", size = 38027, upload-time = "2026-02-26T21:41:17.225Z" }
@@ -3025,12 +3269,15 @@ version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "einops" },
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "safetensors" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "sys_platform != 'darwin'" },
-    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "torchvision", version = "0.27.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "sys_platform != 'darwin'" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0+rocm7.14.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torchvision", version = "0.27.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torchvision", version = "0.27.0+rocm7.14.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2a/8f/ab4565c23dd67a036ab72101a830cebd7ca026b2fddf5771bbf6284f6228/spandrel-0.4.2.tar.gz", hash = "sha256:fefa4ea966c6a5b7721dcf24f3e2062a5a96a395c8bedcb570fb55971fdcbccb", size = 247544, upload-time = "2026-02-21T01:52:26.342Z" }
@@ -3096,13 +3343,12 @@ wheels = [
 [[package]]
 name = "sympy"
 version = "1.14.0"
-source = { registry = "https://download.pytorch.org/whl/cu132" }
+source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }
 dependencies = [
     { name = "mpmath" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5" },
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/sympy-1.14.0-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -3113,9 +3359,11 @@ dependencies = [
     { name = "absl-py" },
     { name = "grpcio" },
     { name = "markdown" },
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "packaging" },
-    { name = "pillow" },
+    { name = "pillow", version = "12.2.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "pillow", version = "12.3.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "protobuf" },
     { name = "setuptools" },
     { name = "tensorboard-data-server" },
@@ -3158,7 +3406,8 @@ name = "tifffile"
 version = "2026.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b7/38/5e2ecef5af2f4fd4a89bb8d6240de9458bab4d51a4cbd97aeb3a0cd618e2/tifffile-2026.6.1.tar.gz", hash = "sha256:626c892c0e899d959b9438e7c0e1491dc154a7fead1f1f37a991724a50eceba9", size = 429694, upload-time = "2026-05-31T23:57:12.165Z" }
 wheels = [
@@ -3173,10 +3422,12 @@ dependencies = [
     { name = "huggingface-hub" },
     { name = "pyyaml" },
     { name = "safetensors" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "sys_platform != 'darwin'" },
-    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "torchvision", version = "0.27.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "sys_platform != 'darwin'" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0+rocm7.14.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torchvision", version = "0.27.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torchvision", version = "0.27.0+rocm7.14.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7b/1e/e924b3b2326a856aaf68586f9c52a5fc81ef45715eca408393b68c597e0e/timm-1.0.26.tar.gz", hash = "sha256:f66f082f2f381cf68431c22714c8b70f723837fa2a185b155961eab90f2d5b10", size = 2419859, upload-time = "2026-03-23T18:12:10.272Z" }
 wheels = [
@@ -3235,17 +3486,24 @@ resolution-markers = [
     "sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform == 'darwin'" },
-    { name = "fsspec", marker = "sys_platform == 'darwin'" },
-    { name = "jinja2", marker = "sys_platform == 'darwin'" },
-    { name = "networkx", marker = "sys_platform == 'darwin'" },
-    { name = "setuptools", marker = "sys_platform == 'darwin'" },
-    { name = "sympy", marker = "sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
+    { name = "filelock", marker = "sys_platform == 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "fsspec", marker = "sys_platform == 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "jinja2", marker = "sys_platform == 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "networkx", marker = "sys_platform == 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "setuptools", marker = "sys_platform == 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "sympy", marker = "sys_platform == 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "triton", marker = "sys_platform == 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/86/ca/01896c80ba921676aa45886b2c5b8d774912de2a1f719de48169c6f755cd/torch-2.12.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:90dd587a5f61bfe1307148b581e2084fc5bc4a06e2b90a20e9a36b81087ff16b", size = 88009511, upload-time = "2026-05-13T14:54:47.411Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/04/52bdaf4787eab6ac7d7f5851dff934e4def0bc8ead9c8fd2b69b3e529699/torch-2.12.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:864392c73b7654f4d2b3ae712f607937d0dbb1101c4555fbb41848106b297f39", size = 426383231, upload-time = "2026-05-13T14:53:32.129Z" },
+    { url = "https://files.pythonhosted.org/packages/49/8a/94bdecd13f5aaa90d45920b89789d9fe7c6f4af8c3cdd7ce01fcb59908fc/torch-2.12.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5d6b560dfa7d56291c07d615c3bb73e8d9943d9b6d87f76cd0d9d570c4797fa6", size = 532269288, upload-time = "2026-05-13T14:53:49.423Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/2f/bdbaaa267de519ef1b73054bf590d8c93c37a266c9a4e24a01bd38b6918f/torch-2.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:3fee918902090ade827643e758e98363278815de583c75d111fdd665ebffde9f", size = 122987706, upload-time = "2026-05-13T14:54:00.335Z" },
     { url = "https://files.pythonhosted.org/packages/9b/ad/e95e822f3538171e22640a7fbe839a1fdb666600bf6487025de2ff03b11a/torch-2.12.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:10ee1448a9f304d3b987eb4656f664ba6e4d7b410ca7a5a7c642199777a2cf88", size = 88319556, upload-time = "2026-05-13T14:54:05.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/07/055d06d985b445d67422d25b033c11cf55bbb81785d4c4e68e28bca5820e/torch-2.12.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:af68dbf403439cae9ceaeaaf92f8352b460787dcd27b92aa05c40dd4a19c0f1e", size = 426397656, upload-time = "2026-05-13T14:52:38.84Z" },
+    { url = "https://files.pythonhosted.org/packages/43/94/b0b4fdc3014122e0a7302fb90086d352aa48f2576f0b252561ebb38c01a8/torch-2.12.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:a6a2eebb237d3b1d9ad3b378e86d9b9e0782afdea8b1e0eba6a13646b9b49c07", size = 532183124, upload-time = "2026-05-13T14:53:16.178Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/c8/052405e6ad05d3237bfe5a4df78f917773956f8e17813a2d44c059068b74/torch-2.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2140e373e9a51a3e22ef62e8d14366d0b470d18f0adf19fdc757368077133a34", size = 123232462, upload-time = "2026-05-13T14:52:27.26Z" },
 ]
 
 [[package]]
@@ -3253,25 +3511,26 @@ name = "torch"
 version = "2.12.0+cu132"
 source = { registry = "https://download.pytorch.org/whl/cu132" }
 resolution-markers = [
-    "sys_platform == 'win32'",
     "platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "(platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
-    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
-    { name = "filelock", marker = "sys_platform != 'darwin'" },
-    { name = "fsspec", marker = "sys_platform != 'darwin'" },
-    { name = "jinja2", marker = "sys_platform != 'darwin'" },
-    { name = "networkx", marker = "sys_platform != 'darwin'" },
-    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
-    { name = "setuptools", marker = "sys_platform != 'darwin'" },
-    { name = "sympy", marker = "sys_platform != 'darwin'" },
-    { name = "triton", marker = "sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
+    { name = "cuda-bindings", marker = "sys_platform == 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "filelock", marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "fsspec", marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "jinja2", marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "networkx", marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "setuptools", marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "sympy", marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "triton", marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "typing-extensions", marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu132/torch-2.12.0%2Bcu132-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:b96a361d18e1117b6aebb9cdf3ec8eb4690eed15fb943d35c02dcae692f616e9", upload-time = "2026-05-13T00:11:32Z" },
@@ -3283,15 +3542,50 @@ wheels = [
 ]
 
 [[package]]
+name = "torch"
+version = "2.12.0+rocm7.14.0"
+source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }
+resolution-markers = [
+    "sys_platform == 'win32'",
+]
+dependencies = [
+    { name = "filelock", marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "fsspec", marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "jinja2", marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "networkx", marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "rocm", extra = ["libraries"], marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "rocm-bootstrap", marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "setuptools", marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "sympy", marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "typing-extensions", marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+]
+wheels = [
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/torch-2.12.0%2Brocm7.14.0-cp313-cp313-linux_x86_64.whl" },
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/torch-2.12.0%2Brocm7.14.0-cp313-cp313-win_amd64.whl" },
+]
+
+[package.optional-dependencies]
+device-gfx1200 = [
+    { name = "amd-torch-device-gfx12-0", marker = "sys_platform == 'win32'" },
+    { name = "amd-torch-device-gfx1200", marker = "sys_platform == 'win32'" },
+]
+device-gfx1201 = [
+    { name = "amd-torch-device-gfx12-0", marker = "sys_platform == 'win32'" },
+    { name = "amd-torch-device-gfx1201", marker = "sys_platform == 'win32'" },
+]
+
+[[package]]
 name = "torchopt"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "graphviz" },
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "optree" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "sys_platform != 'darwin'" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0+rocm7.14.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fe/a2/f132f73ceb74e6af48ec20376bfb53a70cedbabfcb7a64cbb766fe8a5bf9/torchopt-0.7.3.tar.gz", hash = "sha256:7b5f1628318a89891b14b7eecf26adde0e9c0590842a16a99fcaa09a91c59c56", size = 119328, upload-time = "2023-11-10T06:32:39.099Z" }
@@ -3304,10 +3598,12 @@ name = "torchsde"
 version = "0.2.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "scipy" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "sys_platform != 'darwin'" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0+rocm7.14.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "trampoline" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/71/a5/ae18ee6de023b3a5462122a43a4c9812c11d275cc585a3d08bf24945c02a/torchsde-0.2.6.tar.gz", hash = "sha256:81d074d3504f9d190f1694fb526395afbe4608ee43a88adb1262a639e5b4778b", size = 48840, upload-time = "2023-09-26T21:52:20.614Z" }
@@ -3323,13 +3619,19 @@ resolution-markers = [
     "sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", marker = "sys_platform == 'darwin'" },
-    { name = "pillow", marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "sys_platform == 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "pillow", version = "12.2.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "sys_platform == 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/ae/36547812e6e047c1d80bcacd1b17a340612b08a6e876e0aabf3d0b9228b0/torchvision-0.27.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:41d6dae73e1af09fa82ded597ae57f2a2314285acde54b25890a8f8e51b999d7", size = 1758826, upload-time = "2026-05-13T14:57:05.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/30/32c4ea842738728a14e3df8c576c62dedcf5ae5cb6a5c984c6429ebe7524/torchvision-0.27.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:70f071c6f74b60d5fe8851636d8d4cd5f4fa29d57fd9348a87a6f17b990b95ba", size = 7789501, upload-time = "2026-05-13T14:56:57.786Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/24/4d0d48684251bd0673f87d633d5d88ab00227983b00591156eed2f86c8d5/torchvision-0.27.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:aaafa6962c9d91f42503de1957d6fa349907d028c06f335bd95da7a5bc57147d", size = 7579868, upload-time = "2026-05-13T14:56:41.618Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/da/e6edd051d2ba25adf23b120fa97f458dff888d098c51e84724f17d2d1470/torchvision-0.27.0-cp313-cp313-win_amd64.whl", hash = "sha256:aee384a2782c89517c4ab9061d2720ba59fd2ffe5ef89d0a149cc2d43abdf521", size = 4092700, upload-time = "2026-05-13T14:57:09.729Z" },
     { url = "https://files.pythonhosted.org/packages/fa/23/95dfa40431360f42ca949bf861434bed51164adfa8fb9801e05bf3194f50/torchvision-0.27.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:c5121f1b9ab09a7f73e837871deb8321551f7eaeb19d87aa00de9191968eae44", size = 1845008, upload-time = "2026-05-13T14:57:03.768Z" },
+    { url = "https://files.pythonhosted.org/packages/23/b9/9dbdf76b2b49a75ba8088df6f7c755bdb520afb6c6dbac0102b46cde5e99/torchvision-0.27.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:1c01f0d1091ae22b9dfc082b0a0fe5faaf053686a29b4fb082ba7691375c73cf", size = 7791430, upload-time = "2026-05-13T14:56:56.206Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/6a/e4a16cf2f3310c2ea7760dc5d9054496844391e0f4c1fae87fefac2f3d9e/torchvision-0.27.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:dadea3c5ecfd05bbb2a3312ab0374f213c58bf6459cb059122e2f4dfe13d10ed", size = 7668441, upload-time = "2026-05-13T14:57:02.127Z" },
+    { url = "https://files.pythonhosted.org/packages/00/70/01b6461117a6a94b5af3f8ee166bb0f045056f3cf187750c110dabfdfffa/torchvision-0.27.0-cp313-cp313t-win_amd64.whl", hash = "sha256:a49e55055a39a8506fe7e59850522cab004efb2c3839f6057658889c1d69c815", size = 4141602, upload-time = "2026-05-13T14:56:53.449Z" },
 ]
 
 [[package]]
@@ -3337,14 +3639,17 @@ name = "torchvision"
 version = "0.27.0+cu132"
 source = { registry = "https://download.pytorch.org/whl/cu132" }
 resolution-markers = [
-    "sys_platform == 'win32'",
     "platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "(platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "numpy", marker = "sys_platform != 'darwin'" },
-    { name = "pillow", marker = "sys_platform != 'darwin'" },
-    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "sys_platform != 'darwin'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform == 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "pillow", version = "12.2.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform == 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "pillow", version = "12.3.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "(sys_platform != 'darwin' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-anima-lora-cuda-windows') or (sys_platform == 'darwin' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu132/torchvision-0.27.0%2Bcu132-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:cd091645082d5db8e5c8e1db7e005cea322c1b17fa1106670c1c9965b0c8f6f3", upload-time = "2026-05-12T16:20:46Z" },
@@ -3356,11 +3661,37 @@ wheels = [
 ]
 
 [[package]]
+name = "torchvision"
+version = "0.27.0+rocm7.14.0"
+source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }
+resolution-markers = [
+    "sys_platform == 'win32'",
+]
+dependencies = [
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "pillow", version = "12.2.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "rocm-bootstrap", marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "torch", version = "2.12.0+rocm7.14.0", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "(sys_platform == 'win32' and extra != 'extra-10-anima-lora-cuda-windows') or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+]
+wheels = [
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/torchvision-0.27.0%2Brocm7.14.0-cp313-cp313-linux_x86_64.whl" },
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/torchvision-0.27.0%2Brocm7.14.0-cp313-cp313-win_amd64.whl" },
+]
+
+[package.optional-dependencies]
+device-gfx1200 = [
+    { name = "amd-torchvision-device-gfx1200", marker = "sys_platform == 'win32'" },
+]
+device-gfx1201 = [
+    { name = "amd-torchvision-device-gfx1201", marker = "sys_platform == 'win32'" },
+]
+
+[[package]]
 name = "tqdm"
 version = "4.67.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
@@ -3381,7 +3712,8 @@ version = "5.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }, marker = "platform_machine != 'aarch64' or sys_platform != 'linux' or (extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows') or (sys_platform != 'linux' and extra == 'extra-10-anima-lora-cuda-windows' and extra == 'extra-10-anima-lora-rocm-windows')" },
     { name = "packaging" },
     { name = "pyyaml" },
     { name = "regex" },
@@ -3398,12 +3730,12 @@ wheels = [
 [[package]]
 name = "triton"
 version = "3.7.0"
-source = { registry = "https://download.pytorch.org/whl/cu132" }
+source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/triton-3.7.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b8295f6c72dcf840d3f4cac25c1b2ff482ef1e9ead23415b48fc2d8373a170d", upload-time = "2026-05-12T14:38:06Z" },
-    { url = "https://download-r2.pytorch.org/whl/triton-3.7.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d01038281f37633f06142f1d4dacc487ea4d451b02eb33edfde758d136628ba2", upload-time = "2026-05-12T14:38:14Z" },
-    { url = "https://download-r2.pytorch.org/whl/triton-3.7.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce7d86842cdafd8c0395fa52dde52f7e010b5fa2bfb86c28ac39f9b424418c52", upload-time = "2026-05-12T14:38:31Z" },
-    { url = "https://download-r2.pytorch.org/whl/triton-3.7.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dabbdb451a8284aa49b236c2a2445372c2d7fd2d0a59e95b1d4c3a31c3c1fc5b", upload-time = "2026-05-12T14:38:40Z" },
+    { url = "https://files.pythonhosted.org/packages/01/e1/a59a583de59b8f62c495d67c80ee3ea97d09e91ac80c4c6e76456ed8d8ac/triton-3.7.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:abdf6beaa89b1bcfb9a43cd990536ce66091a997841a4814b260b7bee4c88c3c", size = 188503209, upload-time = "2026-05-07T19:05:17.935Z" },
+    { url = "https://files.pythonhosted.org/packages/30/b1/b7507bb9815d403927c8dd51d4158ed2e11751a92dbc118a044f247b6848/triton-3.7.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a35d7afe3f3f058e7ec49fcce09794049e0ffc5c59019ac25ec3413741b8c4e7", size = 201453566, upload-time = "2026-05-07T18:46:20.427Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/8f/0bea7a6a0c989315c9135a1d7fb37e41905cfb3a17cbc1f10044ebd4cc3a/triton-3.7.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cc1d61c172d257db80ddf42595131fb196ad2e9bdd751e90fe2ef13531734e8b", size = 188612899, upload-time = "2026-05-07T19:05:24.955Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/02/d96f57828d0912aec733b9bc7e0e7dbfd2c6f079a8fa433ac25cb93d1a30/triton-3.7.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70fb9bbdc9f400afc54bbf6eb2670af28829a6ae3996863317964783141daf56", size = 201553816, upload-time = "2026-05-07T18:46:27.49Z" },
 ]
 
 [[package]]
@@ -3432,9 +3764,9 @@ wheels = [
 [[package]]
 name = "typing-extensions"
 version = "4.15.0"
-source = { registry = "https://download.pytorch.org/whl/cu132" }
+source = { registry = "https://repo.amd.com/rocm/whl-multi-arch/" }
 wheels = [
-    { url = "https://download.pytorch.org/whl/typing_extensions-4.15.0-py3-none-any.whl" },
+    { url = "https://repo.amd.com/rocm/whl-multi-arch/typing_extensions-4.15.0-py3-none-any.whl" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #88.

## What changed

- add `ANIMA_BACKEND=auto|cuda|rocm` selection to the Windows installer
- preserve the existing NVIDIA CUDA 13.2 path and skip the CUDA toolkit step for ROCm
- split Windows accelerator dependencies into mutually exclusive `cuda-windows` and `rocm-windows` extras
- resolve ROCm PyTorch 2.12 / torchvision 0.27 from AMD's official ROCm 7.14 multi-arch index
- scope the initial ROCm package set to RDNA 4 (`gfx1200` / `gfx1201`) instead of AMD's currently unresolvable `device-all` extra
- keep the selected backend across `make update`
- fall back from CUDA Flash Attention to PyTorch SDPA when HIP is detected, while leaving `torch_compile = true`
- add a post-install ROCm tensor + `torch.compile` + bf16 SDPA + backward smoke test
- document automatic selection, manual overrides, and manual `uv sync` commands

## Why

The previous Windows environment was CUDA-only at every layer: the CUDA toolkit check was unconditional, Torch came from the cu132 index, and Flash Attention / Triton were installed as normal Windows dependencies. Installing ROCm Torch first could therefore be undone by a later `uv sync`.

The backend extras and uv conflict declaration make CUDA and ROCm mutually exclusive. The installer and updater always reuse the chosen extra, so they cannot silently cross package indexes.

## AMD Flash Attention

This PR deliberately does not install an AMD Flash Attention implementation. On the tested Anima training workload, AMD FA worked but was about 3x slower than PyTorch SDPA. HIP therefore normalizes `attn_mode = "flash"` to `"torch"`; users keep the working compile path without adding an optional attention dependency.

## Validation

- `uv lock --check` — resolved 236 packages
- clean exact `uv sync --locked --no-dev --extra rocm-windows` — installed `torch==2.12.0+rocm7.14.0`, HIP `7.14.60850`, gfx1200/gfx1201 ROCm packages, and no CUDA Torch or Flash Attention
- `uv sync --dry-run --no-dev --extra cuda-windows` — retains `torch==2.12.0+cu132`, the existing Flash Attention wheel, and no ROCm packages
- `pytest tests/test_rocm_backend.py -q` — 9 passed
- PowerShell parser check for `install.ps1` — passed
- targeted Ruff checks — passed
- real AMD ROCm 7.14 smoke on RX 9060 XT (`gfx1200`) — tensor allocation, `torch.compile`, bf16 SDPA, backward, finite-value checks, and synchronize passed
- real AMD ROCm 7.14 smoke on RX 9070 XT (`gfx1201`) — the same checks passed

## Compatibility

- NVIDIA behavior remains CUDA 13.2 + Flash Attention.
- ROCm changes only backend selection and attention dispatch; optimizer, gradient checkpointing, and compile defaults are unchanged.
- Windows manual clones must select one extra for exact sync: `uv sync --extra cuda-windows` or `uv sync --extra rocm-windows`.
